### PR TITLE
docs: Add administrator and operations documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,62 @@
 # Deep Dive Brewing Co — Website
 
-> Release: **1.0.2** (package version `1.0.2`)
+> Release: **1.0.2** (package version `1.0.2`)  
 > Status: **Active**
 
 Public-facing marketing and trade website for **Deep Dive Brewing Co**, a craft brewery on Saba.
 
-## Tech Stack
+## Live URLs
 
-- **Next.js 16** (App Router, server components)
+- **Production site:** https://deepdivebrewing.com
+- **Admin dashboard:** https://deepdivebrewing.com/admin
+
+## What this project does
+
+The site markets Deep Dive Brewing Co beers, tells the brewery story, lists partner venues, and collects wholesale/trade inquiries. A small admin dashboard lets authorized staff manage the beer catalog, venue list, and trigger site rebuilds after content changes.
+
+## Technology overview
+
+- **Next.js 16** with App Router and React Server Components
 - **TypeScript**
-- **Tailwind CSS v4** + **shadcn/ui**
-- **Firebase** (Firestore, Storage)
+- **Tailwind CSS v4** and **shadcn/ui**
+- **Firebase** — Firestore, Storage, and Authentication (Google sign-in)
 - **MDX** for long-form content
-- **Vercel** for deployment
+- **Vercel** hosting, preview deployments, and Analytics/Speed Insights
+- **Google Analytics 4** via GTM/gtag
+- **Resend** for trade-inquiry email delivery
 
-## Getting Started
+## Repository structure
 
-### Prerequisites
+```
+app/                 → Next.js App Router routes
+components/          → React components, including admin UI
+components/ui/       → shadcn/ui building blocks
+lib/                 → Firebase clients, data helpers, types, utilities
+content/             → MDX content files
+public/              → Static assets, favicons, manifest, videos, photos
+docs/                → Administrator and operations guides
+scripts/             → Utility and verification scripts
+firestore.rules      → Firestore security rules
+storage.rules        → Firebase Storage security rules
+```
+
+See the [docs/](./docs/) directory for detailed guides.
+
+## Prerequisites
 
 - Node.js 20+
 - npm
 - A Firebase project with Firestore and Storage enabled
+- Vercel project (for deployment)
 
-### Setup
+## Local setup
 
-1. Clone the repository
+1. Clone the repository.
 2. Install dependencies:
    ```bash
    npm install
    ```
-3. Copy the environment template and fill in your Firebase credentials:
+3. Copy the environment template and fill in your values:
    ```bash
    cp .env.local.example .env.local
    ```
@@ -37,81 +64,13 @@ Public-facing marketing and trade website for **Deep Dive Brewing Co**, a craft 
    ```bash
    npm run dev
    ```
-5. Open [http://localhost:3000](http://localhost:3000)
+5. Open [http://localhost:3000](http://localhost:3000).
 
-## Project Structure
+> Local development can use dummy Firebase values, but populated beer/venue data and image uploads require real Firebase credentials.
 
-```
-app/              → Routes (App Router)
-components/ui/    → shadcn/ui components
-lib/              → Firebase client, data fetching, types, utilities
-content/          → MDX content files
-public/           → Static assets, favicons, manifest
-```
+## Required environment variables
 
-## Routes
-
-| Path | Description |
-|---|---|
-| `/` | Home |
-| `/beers` | Beer catalog (Firestore) |
-| `/beers/[slug]` | Beer detail page (Firestore) |
-| `/where-to-buy` | Venue list (Firestore) |
-| `/about` | About page (MDX) |
-| `/contact` | Contact page (MDX) |
-| `/trade` | Wholesale info (MDX) |
-| `/admin` | Admin dashboard (Firebase Auth gated) |
-
-## Firestore Collections
-
-- **beers** — Beer catalog entries
-- **venues** — Bars, restaurants, retailers
-- **tradeLeads** — Wholesale inquiry submissions
-- **meta/siteRebuild** — Rebuild cooldown + audit metadata
-
-## Design System
-
-See [THEME_AND_BRANDING.md](./THEME_AND_BRANDING.md) for the complete visual design system including colors, typography, spacing, and animation guidelines.
-
-## Scripts
-
-| Command | Description |
-|---|---|
-| `npm run dev` | Start development server |
-| `npm run build` | Production build |
-| `npm run start` | Start production server |
-| `npm run lint` | Run ESLint |
-| `npm run optimize-assets` | Recompress hero image and generate OG image |
-
-## Deployment
-
-Deployed to [Vercel](https://vercel.com). Push to `main` to trigger a production deploy.
-
-### Admin Rebuild Flow
-
-The admin dashboard includes a **Rebuild Site** button that:
-
-1. Verifies admin identity with Firebase ID token
-2. Calls the server route `POST /api/admin/rebuild`
-3. Triggers a Vercel Deploy Hook
-4. Enforces cooldown to prevent repeated rebuilds
-
-The dashboard also shows:
-
-- Last rebuild triggered by / at
-- Warning when content has changed since the last rebuild
-
-## Public Repository Notice
-
-This repository is public for transparency and reference. No secrets, API keys, or private keys are stored in source control. All sensitive configuration is injected via environment variables (see `.env.local.example`).
-
-The public Firebase configuration values are safe to expose; access to Firebase services is controlled by Firebase Security Rules and App Check.
-
-## Environment Variables
-
-See `.env.local.example` for all required keys.
-
-### Core App
+See `.env.local.example` for the complete list. Key variables include:
 
 - `NEXT_PUBLIC_FIREBASE_API_KEY`
 - `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
@@ -124,42 +83,71 @@ See `.env.local.example` for all required keys.
 - `NEXT_PUBLIC_GA_ID`
 - `RESEND_API_KEY`
 - `TRADE_INQUIRY_TO_EMAIL`
-
-### Admin Rebuild Endpoint
-
 - `VERCEL_DEPLOY_HOOK_URL`
 - `FIREBASE_ADMIN_PROJECT_ID`
 - `FIREBASE_ADMIN_CLIENT_EMAIL`
 - `FIREBASE_ADMIN_PRIVATE_KEY`
-- `ADMIN_REBUILD_COOLDOWN_MS` (optional, default 600000)
+- `ADMIN_REBUILD_COOLDOWN_MS` (optional, default `600000`)
 
-## Shelving / Handoff Notes
+Never commit real values to source control. `.env.local` is already ignored by Git.
 
-When resuming work later:
+## Firebase services used
 
-1. Confirm Vercel env vars are still set (especially admin + deploy hook values).
-2. Verify Firebase Auth Google provider is enabled for admin emails.
-3. Re-deploy Firebase rules (`firestore.rules`, `storage.rules`) if needed.
-4. Test `/admin` login, save a record, and run one rebuild.
+- **Firestore** — beer records, venue records, trade leads metadata, and rebuild audit metadata.
+- **Firebase Storage** — beer card and hero images.
+- **Firebase Authentication** — Google sign-in restricted to an allow-list of admin emails.
 
-## Legal & Licensing
+## Development commands
 
-- **Copyright:** © 2024–2026 Deep Dive Brews, BV, trading as **Deep Dive Brewing Co**.
-- **Code:** Released under the [MIT License](./LICENSE).
-- **Brand & Content:** The Deep Dive Brewing Co name, logo, artwork, photography, and written content are the property of Deep Dive Brews, BV, and are not licensed for reuse, redistribution, or modification without explicit written permission.
-- **Third-party assets:** Any third-party libraries remain under their respective licenses.
+| Command | Description |
+|---|---|
+| `npm run dev` | Start the Next.js development server |
+| `npm run build` | Build for production |
+| `npm run start` | Start the production server locally |
+| `npm run lint` | Run ESLint |
+| `npx tsc --noEmit` | Run TypeScript type-checking |
+| `npm run optimize-assets` | Recompress hero image and generate OG image |
+| `npm run seed:beers` | Seed sample beer data (developer script) |
+| `npm run seed:venues` | Seed sample venue data (developer script) |
 
-## Privacy & Data Handling
+> There is no automated test suite currently. Type-checking and linting provide static verification.
 
-This site uses:
+## Deployment overview
 
-- **Google Analytics** for aggregated traffic measurement (via `NEXT_PUBLIC_GA_ID`).
-- **Vercel Analytics** and **Vercel Speed Insights** for performance telemetry.
-- **Firebase** for Firestore data and Storage assets.
-- **Resend** for sending trade-inquiry emails.
+The site deploys on Vercel.
 
-No personal data is stored in this repository. Wholesale inquiry submissions are sent to the configured email address and may be stored in Firestore for follow-up.
+- Pushes and pull requests automatically create preview deployments.
+- Merging into the production branch triggers a production deploy.
+- The admin dashboard can trigger an on-demand rebuild by calling a Vercel Deploy Hook (`POST /api/admin/rebuild`).
 
-## Security
+See [docs/operations/deployment.md](./docs/operations/deployment.md) for branch workflow, rollback, and smoke-test steps.
 
-If you discover a security vulnerability in this codebase or the live site, please email **info@deepdivebrewing.com** with details. Do not open a public issue for security-sensitive bugs.
+## Documentation
+
+### For administrators
+
+- [Admin handbook](./docs/admin/README.md)
+- [Login and access](./docs/admin/login-and-access.md)
+- [Managing beers](./docs/admin/managing-beers.md)
+- [Managing locations](./docs/admin/managing-locations.md)
+- [Images and storage](./docs/admin/images-and-storage.md)
+- [Trade inquiries](./docs/admin/trade-inquiries.md)
+
+### For developers and operators
+
+- [Deployment guide](./docs/operations/deployment.md)
+- [Troubleshooting guide](./docs/operations/troubleshooting.md)
+- [Post-deployment checklist](./docs/operations/post-deployment-checklist.md)
+
+## Security and secret management
+
+- No secrets, API keys, or private keys are stored in source control.
+- All sensitive configuration is injected via environment variables.
+- Firebase client configuration values prefixed with `NEXT_PUBLIC_` are safe to expose in the browser; access is controlled by Firebase Security Rules and the admin allow-list.
+- The Firebase service-account key (`FIREBASE_ADMIN_PRIVATE_KEY`) must stay in Vercel environment variables and local `.env.local` only.
+
+If you discover a security vulnerability, email **info@deepdivebrewing.com** instead of opening a public issue.
+
+## Public repository notice
+
+This repository is public for transparency and reference. The Deep Dive Brewing Co name, logo, artwork, photography, and written content are the property of Deep Dive Brews, BV, and are not licensed for reuse without explicit written permission. Third-party libraries remain under their respective licenses.

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,0 +1,68 @@
+# Administrator Handbook
+
+This guide is for the staff and owners who keep the Deep Dive Brewing Co website up to date.
+
+> **Warning:** The admin dashboard edits **production content**. Changes you save are visible to customers as soon as the public pages refresh or are rebuilt. Always double-check your work before saving.
+
+## What the admin area controls
+
+The admin dashboard lets authorized users:
+
+- View, create, and edit beer records.
+- View, create, and edit venue/partner records.
+- Upload beer card and hero images to Firebase Storage.
+- Trigger a site rebuild so static pages (such as the beer listing and Where to Buy page) show the latest content.
+
+It does **not** currently let you delete beer or venue records directly. To remove something from public view, uncheck the **Public** checkbox and save.
+
+## Who should have access
+
+Only a small set of trusted Deep Dive Brewing Co staff should be admins. Access is granted through an email allow-list stored in the codebase and in Firebase Security Rules. If someone needs access, an existing owner must add their Google email to both places and redeploy the rules. See [Login and access](./login-and-access.md#how-owner-grants-or-removes-access) for the exact steps.
+
+## How to reach the admin login
+
+1. Go to https://deepdivebrewing.com/admin.
+2. You will see a sign-in screen with a **Sign in with Google** button.
+3. Click the button and choose your authorized Google account.
+4. If the account is on the allow-list, the full dashboard appears.
+
+## What a successful login looks like
+
+After signing in, the dashboard shows:
+
+- Your email address at the top.
+- A **Rebuild Site** button.
+- The last rebuild information.
+- Two tabs: **Beers** and **Venues**.
+
+If you see a message saying your email is not authorized, you are signed in to Google but not on the allow-list. Sign out and contact an owner.
+
+## How to sign out
+
+Click the **Sign out** button in the top-right area of the dashboard. After signing out, you return to the sign-in screen.
+
+## How to request access
+
+If you need admin access:
+
+1. Make sure you have a Google account you can use.
+2. Ask an existing owner to add your email address to the admin allow-list. The owner will update `lib/admin-emails.ts`, `firestore.rules`, and `storage.rules`, then redeploy the rules.
+3. Once that is done, sign in at https://deepdivebrewing.com/admin.
+
+## Recommended browser and troubleshooting
+
+- Use a modern browser such as Chrome, Edge, Firefox, or Safari.
+- Enable cookies and local storage for `deepdivebrewing.com`.
+- Allow popups from `deepdivebrewing.com` so the Google sign-in popup can open.
+- Disable ad blockers or privacy extensions temporarily if sign-in fails.
+- If you see a blank page or login loop, clear cookies for the site and try again.
+
+For detailed login troubleshooting, see [Login and access](./login-and-access.md).
+
+## Task-specific guides
+
+- [Login and access](./login-and-access.md)
+- [Managing beers](./managing-beers.md)
+- [Managing locations](./managing-locations.md)
+- [Images and storage](./images-and-storage.md)
+- [Trade inquiries](./trade-inquiries.md)

--- a/docs/admin/images-and-storage.md
+++ b/docs/admin/images-and-storage.md
@@ -1,0 +1,208 @@
+# Images and Storage
+
+This guide explains how beer images are stored, how they appear on the public site, and how to fix common image problems.
+
+## Where beer images are stored
+
+Beer card and hero images are stored in **Firebase Cloud Storage** in the project's configured bucket. The bucket name comes from the `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` environment variable.
+
+When you upload an image from the admin dashboard, the file is placed in a path like:
+
+```
+beers/<beer-slug>/<slug>_<kind>_<timestamp>.<extension>
+```
+
+For example:
+
+```
+beers/island-neipa/island-neipa_hero_1699123456789.jpg
+```
+
+Only the **object path** is saved in the beer record. The public site converts the path into a full download URL when the page loads.
+
+## How Firebase Storage URLs are generated
+
+The path stored in Firestore is turned into a URL using the project's bucket:
+
+```
+https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<encoded-path>?alt=media
+```
+
+This URL is then passed through Next.js Image Optimization, which rewrites it to an optimized, resized image URL such as `/_next/image?url=...`.
+
+## Expected bucket name
+
+The bucket name is the value of `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`. It usually looks like `<project-id>.appspot.com` or a custom bucket name. The application reads it from the environment at build or runtime; do not change it in the code.
+
+## How Next.js Image Optimization handles Firebase images
+
+Next.js is configured to optimize external images from `firebasestorage.googleapis.com`. The configuration lives in `next.config.ts` under `images.remotePatterns`.
+
+When a page loads a beer image:
+
+1. Next.js receives the Firebase Storage URL.
+2. It checks that the hostname is allowed.
+3. It fetches the image from Firebase Storage.
+4. It serves an optimized WebP/AVIF copy sized for the visitor's device.
+
+This means the first request after an upload may take slightly longer while Next.js caches the optimized version.
+
+## Permitted remote-image host
+
+Only `firebasestorage.googleapis.com` is permitted by the Next.js image configuration. If an image URL points anywhere else, Next.js will refuse to optimize it and the image will not load.
+
+## Recommended image specifications
+
+### File types
+
+Use one of these formats:
+
+- **WebP** — best balance of quality and file size (preferred).
+- **AVIF** — even smaller, but older browsers may not support it.
+- **JPEG** — widely compatible; use when WebP/AVIF is unavailable.
+- **PNG** — only when transparency is required.
+
+### Dimensions and aspect ratios
+
+- **Card image:** portrait, approximately 4:5 ratio. Recommended size 800 × 1000 pixels.
+- **Hero image:** landscape, approximately 16:9 ratio. Recommended size 1200 × 675 pixels.
+- **Open Graph / social share image:** 1200 × 630 pixels (this is the default `og-default.jpg` in `public/photos/`).
+
+### Compression
+
+- Keep each image under 500 KB when possible.
+- Use quality 80–85 for photographs.
+- Avoid uploading extremely large originals; Next.js resizes them, but smaller sources load faster.
+
+### File-naming conventions
+
+The admin dashboard renames uploaded files automatically, but it helps to start with a clean filename:
+
+- Use lowercase letters, numbers, and hyphens only.
+- Avoid spaces and special characters.
+- Example: `island-neipa-hero.jpg`.
+
+## Accessibility
+
+Beer images must have useful alternative text. The public site uses the beer name as the image `alt` attribute. Make sure the **Name** field is descriptive, for example "Island NEIPA" rather than generic text.
+
+## Replacing images safely
+
+> **Warning:** The admin dashboard does not delete old files from Firebase Storage. Uploading a replacement creates a new file, and the beer record now points to the new file. The old file remains in the bucket until a developer removes it.
+
+To replace an image:
+
+1. Open the beer record.
+2. Under **Upload Card Image** or **Upload Hero Image**, choose the new file.
+3. Wait for the upload to finish. The path field updates automatically.
+4. Click **Save Beer**.
+5. Visit the public beer page to confirm the new image appears.
+
+## Caching considerations
+
+- Firebase Storage URLs are public and cacheable.
+- Next.js Image Optimization caches the optimized versions. The cache time-to-live is set to one year (`minimumCacheTTL: 31536000`).
+- Because the filename includes a timestamp, replacing an image produces a fresh URL, so visitors see the update quickly.
+- If you change an image but keep the same filename and URL, visitors may see the cached version until the cache expires.
+
+## Verifying an uploaded image on the public site
+
+1. Save the beer record after uploading.
+2. Open the beer detail page at `https://deepdivebrewing.com/beers/<slug>`.
+3. Check that the hero image loads.
+4. Visit `/beers` and confirm the card image loads. Remember that listing pages may need a site rebuild to show a brand-new beer.
+
+## Diagnosing image problems
+
+### Missing or deleted file
+
+**Symptom:** The image URL returns a 404 from Firebase Storage.
+
+**Checks:**
+
+- Open the image URL directly in a browser.
+- Look in the Firebase Storage console under the `beers/<slug>/` folder.
+
+**Fix:** Re-upload the image in the admin dashboard and save the beer record.
+
+### Firebase billing problem
+
+**Symptom:** Image URLs return `402 Payment Required` or `403 Forbidden` from `firebasestorage.googleapis.com`. Next.js may show `502 OPTIMIZED_EXTERNAL_IMAGE_REQUEST_INVALID`.
+
+**Cause:** Cloud Storage for Firebase requires the **Blaze** (pay-as-you-go) plan. If billing is disabled or the project returns to the Spark plan, Storage requests can fail.
+
+**Important lesson:** The files may still exist in the bucket even though they are temporarily inaccessible. Re-enabling billing usually restores access without needing to re-upload anything.
+
+**Fix:**
+
+1. Open the Firebase project billing section.
+2. Confirm the Blaze plan is active and a valid payment method is attached.
+3. Wait a few minutes for Firebase services to resume.
+4. Re-check the image URLs.
+
+> Do not re-upload all images until you have confirmed billing is active; repeated uploads may incur unnecessary charges.
+
+### Storage permission problem
+
+**Symptom:** Images return `403 Forbidden` even though billing is enabled.
+
+**Checks:**
+
+- Review `storage.rules`. Public read is allowed (`allow read: if true;`), so public pages should be able to load images.
+- Confirm the rules have been deployed to Firebase.
+
+**Fix:** Redeploy `storage.rules` from the project root:
+
+```bash
+firebase deploy --only storage
+```
+
+or ask a developer to deploy the rules.
+
+### Invalid URL
+
+**Symptom:** The browser tries to load a malformed image URL, or the URL does not point to an existing object.
+
+**Checks:**
+
+- Open the beer record and look at the **Card Image Path** or **Hero Image Path** field.
+- The value should look like `beers/<slug>/<filename>.jpg`, not a full URL.
+
+**Fix:** Re-upload the image, which resets the path, then save the beer.
+
+### Next.js `remotePatterns` problem
+
+**Symptom:** Next.js shows an error like `"hostname firebasestorage.googleapis.com is not configured"`.
+
+**Cause:** The image hostname is not in `next.config.ts` `images.remotePatterns`.
+
+**Fix:** This should already be configured. If it is missing, add `firebasestorage.googleapis.com` to `images.remotePatterns` in `next.config.ts`, then rebuild and redeploy. Do not add unrelated hostnames.
+
+### CSP problem
+
+**Symptom:** The browser console shows a `img-src` Content-Security-Policy violation.
+
+**Checks:**
+
+- Confirm `img-src` in `next.config.ts` includes `https://firebasestorage.googleapis.com`.
+
+**Fix:** Add or confirm the Firebase Storage origin in `img-src`, then rebuild and redeploy.
+
+### Stale browser or CDN cache
+
+**Symptom:** You uploaded a new image, but you still see the old one.
+
+**Checks:**
+
+- Hard-refresh the page (`Ctrl+Shift+R` or `Cmd+Shift+R`).
+- Open the image URL directly and compare it with the path in the beer record.
+- Check whether the filename includes a new timestamp.
+
+**Fix:** If the URL is the same, the cache is likely the cause. Wait a few minutes, or upload again with a different filename. In most cases, the timestamp in the filename avoids this problem.
+
+## General safety tips
+
+- Always upload images **after** the beer slug is finalized.
+- Use the upload buttons rather than typing paths by hand.
+- Keep image files reasonably small.
+- Do not store personal information, credentials, or payment details in image filenames or metadata.

--- a/docs/admin/login-and-access.md
+++ b/docs/admin/login-and-access.md
@@ -1,0 +1,190 @@
+# Login and Access
+
+This guide explains how to sign in to the Deep Dive Brewing Co admin dashboard, how authorization is decided, and how to fix common login problems.
+
+## Before you start
+
+- Use a modern browser.
+- Make sure popups are allowed for `deepdivebrewing.com`.
+- Make sure cookies and third-party storage are not blocked.
+- Have the Google account ready that an owner has added to the admin allow-list.
+
+## Signing in
+
+1. Open https://deepdivebrewing.com/admin.
+2. Click **Sign in with Google**.
+3. A Google popup appears. Choose the authorized Google account.
+4. The popup closes and the dashboard loads.
+
+If you are already signed in to Google with only one account, the popup may skip the account chooser and sign you in immediately.
+
+## What happens after you choose an account
+
+- The site verifies your Google ID token.
+- It checks whether your email address is in the admin allow-list.
+- If you are authorized, the dashboard loads beer and venue data from Firestore.
+- If you are not authorized, you see a message such as `your-email@example.com is not authorized for admin access` and a **Sign out** button.
+
+## How administrator authorization is determined
+
+Authorization is controlled by an allow-list of email addresses.
+
+- The same list is used in two places:
+  - The React admin dashboard code (`lib/admin-emails.ts`) checks it on the client for UI gating.
+  - The server-side API route and Firebase Security Rules also enforce it for any data changes or rebuilds.
+- If the lists are out of sync, a user might see the dashboard but be unable to save data or trigger a rebuild.
+
+## How an owner safely grants or removes access
+
+> **Warning:** Changing access requires editing code and redeploying Firebase rules. Only an owner or developer should do this.
+
+To grant access:
+
+1. Add the email address to `lib/admin-emails.ts`.
+2. Add the same email address to the allow-list in `firestore.rules`.
+3. Add the same email address to the allow-list in `storage.rules`.
+4. Redeploy the Firebase rules to the Firebase project.
+5. Rebuild and redeploy the website so the updated `lib/admin-emails.ts` is included.
+6. Ask the new admin to sign in at https://deepdivebrewing.com/admin.
+
+To remove access, reverse the steps: remove the email from all three files, redeploy the rules, and rebuild the site.
+
+## Firebase Authentication authorized domains
+
+Firebase Authentication only allows sign-in from registered domains. The production domain `deepdivebrewing.com` and any Vercel preview domains must be listed in the Firebase Authentication console under **Settings > Authorized domains**.
+
+If a new preview domain is not authorized, Google sign-in will fail with an `auth/unauthorized-domain` error. Add the exact domain to the Firebase console and try again.
+
+## Required CSP origins for Firebase Auth
+
+The site uses a Content Security Policy (CSP) to protect visitors. Firebase Auth needs the following origins to be permitted:
+
+- `connect-src` — `https://*.googleapis.com`, `https://*.firebaseio.com`, `https://accounts.google.com`, `https://apis.google.com`
+- `frame-src` — `https://accounts.google.com` and the Firebase Auth helper iframe origin
+
+The Firebase Auth helper domain currently used by the project is:
+
+```
+https://deepdivebrewing-web.firebaseapp.com
+```
+
+This domain is derived from the `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` environment variable at build time. It must remain permitted by the site's `frame-src` CSP while it is used as the Firebase `authDomain`.
+
+## Popup, cookie, and privacy-browser considerations
+
+- **Popup blockers** can prevent the Google sign-in window from opening. Allow popups for `deepdivebrewing.com`.
+- **Strict privacy browsers or containers** may block the Firebase Auth helper iframe. If this happens, sign-in may fail even though the button is visible.
+- **Third-party cookie blocking** in some browsers can interfere with the Google Identity Services flow.
+
+## Signing out
+
+Click the **Sign out** button in the dashboard header. This signs you out of Firebase Auth on the site. It does not sign you out of Google entirely.
+
+## Troubleshooting
+
+### `auth/popup-closed-by-user`
+
+**Symptom:** You clicked **Sign in with Google**, but the popup closed before finishing.
+
+**Likely causes:**
+
+- You closed the popup yourself.
+- A popup blocker closed it.
+- The browser refused the popup.
+
+**Fix:**
+
+1. Allow popups for `deepdivebrewing.com`.
+2. Try signing in again.
+3. If the popup still closes, open the browser console and report any red error messages to the developer.
+
+### Firebase Auth iframe blocked by CSP
+
+**Symptom:** The sign-in button is visible, but after clicking it nothing happens, or the browser console shows a `frame-src` violation for `deepdivebrewing-web.firebaseapp.com`.
+
+**Likely cause:** The Content-Security-Policy header does not permit the Firebase Auth helper iframe origin.
+
+**Fix:**
+
+- The `frame-src` directive in `next.config.ts` must include the value of `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` as an `https://` origin.
+- If the environment variable changes, the site must be rebuilt and redeployed.
+- Do not change the policy to `https://*.firebaseapp.com`; keep the exact origin.
+
+### `auth/unauthorized-domain`
+
+**Symptom:** A Firebase error says the domain is not authorized.
+
+**Likely cause:** The current domain (production or a Vercel preview) is not in Firebase Authentication authorized domains.
+
+**Fix:**
+
+1. Open the Firebase Authentication console.
+2. Go to **Settings > Authorized domains**.
+3. Add the exact domain shown in the browser address bar.
+4. Try signing in again.
+
+### Popup blocked
+
+**Symptom:** The browser shows a warning that a popup was blocked.
+
+**Fix:**
+
+- Allow popups for `deepdivebrewing.com`.
+- Temporarily disable popup blockers or privacy extensions for this site.
+
+### Wrong Google account
+
+**Symptom:** You signed in but see an unauthorized email address.
+
+**Fix:**
+
+1. Click **Sign out**.
+2. Sign in again and choose the correct Google account.
+3. If you are signed in to multiple Google accounts, you may need to sign out of Google entirely or use an incognito/private window.
+
+### Authenticated but not authorized
+
+**Symptom:** The dashboard says your email is signed in but is not authorized.
+
+**Likely cause:** Your email is not in `lib/admin-emails.ts`, `firestore.rules`, and `storage.rules`.
+
+**Fix:**
+
+- Ask an owner to add your email to all three files, redeploy the rules, and rebuild the site.
+
+### Expired session
+
+**Symptom:** You were logged in before, but now the dashboard shows the sign-in screen.
+
+**Likely cause:** Firebase Auth sessions can expire, especially after long periods of inactivity or password changes.
+
+**Fix:**
+
+1. Click **Sign in with Google** again.
+2. If the issue repeats, clear cookies for `deepdivebrewing.com` and sign in fresh.
+
+### Repeated login loop
+
+**Symptom:** You keep returning to the sign-in screen after successfully signing in.
+
+**Likely causes:**
+
+- Third-party cookies or storage are blocked.
+- The Firebase Auth helper iframe is being blocked.
+- A privacy extension is interfering.
+
+**Fix:**
+
+1. Disable privacy extensions for `deepdivebrewing.com`.
+2. Allow third-party cookies and storage.
+3. Try a different browser or an incognito/private window.
+4. Check the browser console for CSP errors.
+
+## Need more help?
+
+If none of these steps resolve the issue, contact the site developer or owner with:
+
+- The exact URL you are visiting.
+- The Google account email you are using.
+- Any messages shown on screen.
+- Any red errors in the browser console.

--- a/docs/admin/managing-beers.md
+++ b/docs/admin/managing-beers.md
@@ -1,0 +1,135 @@
+# Managing Beers
+
+This guide explains how to update the beer catalog on the Deep Dive Brewing Co website.
+
+> **Warning:** Saving changes writes to the live production database immediately. Always review your work before clicking **Save Beer**.
+
+## Viewing the beer list
+
+1. Sign in to the admin dashboard at https://deepdivebrewing.com/admin.
+2. Make sure the **Beers** tab is selected.
+3. The left panel shows all beer records sorted by the **Sort Order** value.
+4. Click a beer name to load it into the form on the right.
+
+## Creating a new beer
+
+1. In the **Beers** tab, click the **New** button above the beer list.
+2. The form on the right clears and shows empty default values.
+3. Fill in the required fields.
+4. Click **Save Beer**.
+
+## Editing an existing beer
+
+1. Click the beer name in the left panel.
+2. Update the fields you want to change.
+3. Click **Save Beer**.
+
+## Available fields
+
+| Field | Required | What it does |
+|---|---|---|
+| **Name** | Yes | The beer's display name on cards, detail pages, and metadata. |
+| **Slug** | Yes | The URL-friendly identifier. Used as the Firestore document ID and in URLs such as `/beers/<slug>`. |
+| **Style** | Yes | The beer style shown under the name, for example "NEIPA" or "Pale Lager". |
+| **Status** | Yes | Choose **Core**, **Seasonal**, or **Limited**. Filters the public beer listing. |
+| **ABV** | Yes | Alcohol by volume as a number, for example `6.5`. |
+| **Sort Order** | Yes | Controls the order beers appear in lists. Lower numbers appear first. |
+| **Short Description** | Recommended | A short paragraph shown on the beer detail page. |
+| **Tasting Notes** | Optional | Comma-separated descriptive words or phrases, for example `citrus, tropical, hazy`. These appear as badges. |
+| **Card Image Path** | Optional | The Firebase Storage path for the thumbnail/card image. Usually filled automatically when you upload an image. |
+| **Hero Image Path** | Optional | The Firebase Storage path for the large detail-page image. Usually filled automatically when you upload an image. |
+| **Public** | Yes | If checked, the beer is visible on the public site. Uncheck to hide it without deleting the record. |
+
+> **Note:** The `Beer` data type also supports `IBU` and `SRM` values, but these are not editable in the current admin form. If those values are set in Firestore directly, they display on the public detail page. The admin UI cannot add or change them.
+
+## Slug rules
+
+- The slug is used as the Firestore document ID.
+- The form automatically converts the slug to lowercase and trims spaces.
+- A good slug is short, descriptive, and URL-safe, for example `island-neipa` or `saba-session-lager`.
+
+> **Important:** If you change the slug of an existing beer, the dashboard saves a **new** Firestore document with the new slug. The old document is not automatically deleted. To avoid duplicate records, create a new beer with the new slug and then edit the old record to uncheck **Public**, or ask a developer to remove the old document from Firestore.
+
+## Beer status
+
+- **Core** — Always available, year-round beers.
+- **Seasonal** — Available during a specific season or period.
+- **Limited** — Small-batch or one-off releases.
+
+The public `/beers` page lets visitors filter by these statuses.
+
+## Uploading images
+
+You can upload images in two ways:
+
+1. **Upload Card Image** — click the file input under **Upload Card Image** and choose an image.
+2. **Upload Hero Image** — click the file input under **Upload Hero Image** and choose an image.
+
+After the upload finishes, the corresponding path field is updated automatically. You must still click **Save Beer** to store the new path in the beer record.
+
+> **Recommendation:** Upload images **after** setting the final slug. If you change the slug after uploading, the image path still refers to the old slug folder and may be confusing to manage.
+
+### Supported formats and recommended dimensions
+
+- **Formats:** JPEG, PNG, WebP, AVIF.
+- **Card image:** portrait orientation. Recommended ratio 4:5, for example 800 × 1000 pixels.
+- **Hero image:** landscape orientation. Recommended ratio 16:9, for example 1200 × 675 pixels.
+- Keep file sizes reasonable (under 500 KB each) so the site loads quickly.
+- Use descriptive filenames before upload; the system renames files automatically.
+
+For more details about storage, caching, and troubleshooting image problems, see [Images and storage](./images-and-storage.md).
+
+## Saving and confirming a change
+
+1. Click **Save Beer**.
+2. A status message appears below the form when the save is complete.
+3. If saving succeeds, the beer list refreshes and the updated beer stays selected.
+
+## How changes appear on the public site
+
+- **Beer detail pages** (`/beers/<slug>`) are rendered on demand, so edits appear on the next visit.
+- **Beer listing page** (`/beers`), **homepage carousel**, and **sitemap** are generated at build time, so they only show new or changed beers after a site rebuild.
+- If you make a change that should appear on a listing page, click **Rebuild Site** in the admin header and wait for the deployment to finish.
+
+## SEO and structured data
+
+Each public beer page automatically generates:
+
+- A page title, meta description, Open Graph tags, and Twitter card.
+- `Product` structured data (JSON-LD) with name, description, image, ABV, IBU (if present), and SRM (if present).
+- Breadcrumb navigation back to `/beers`.
+
+The meta description uses the beer name, style, ABV, and first tasting note. Writing a clear **Short Description** and **Style** improves search-engine snippets.
+
+## Removing or hiding a beer
+
+The admin form does **not** have a delete button. To remove a beer from public view:
+
+1. Open the beer record.
+2. Uncheck **Public**.
+3. Click **Save Beer**.
+
+The beer record remains in Firestore but no longer appears on public pages. Only a developer can permanently delete the document from Firestore.
+
+## Recovery options if content is changed incorrectly
+
+- **Wrong text but correct slug:** Edit the beer again and save the corrected values.
+- **Wrong slug created a duplicate:** Edit the old record to uncheck **Public**, then update the new record as needed. Ask a developer to delete the duplicate document if necessary.
+- **Wrong image uploaded:** Upload a replacement image and save the beer. The old image file remains in Storage; ask a developer to clean it up if needed.
+- **Accidentally saved while incomplete:** Re-open the record, complete the fields, and save again.
+
+## Pre-publish checklist
+
+Before saving a new or updated beer, confirm:
+
+- [ ] Name and slug are correct.
+- [ ] Slug is URL-friendly and lowercase.
+- [ ] Style is filled in.
+- [ ] ABV is a number, for example `5.2`.
+- [ ] Status matches the release plan (Core, Seasonal, or Limited).
+- [ ] Sort order is set so the beer appears in the right place.
+- [ ] Short description reads well for visitors and search engines.
+- [ ] Tasting notes are spelled correctly and comma-separated.
+- [ ] Card and hero images are uploaded and look right on the public site.
+- [ ] **Public** is checked if the beer should be live.
+- [ ] If the change affects listing pages, a rebuild is triggered afterward.

--- a/docs/admin/managing-locations.md
+++ b/docs/admin/managing-locations.md
@@ -1,0 +1,136 @@
+# Managing Locations
+
+This guide explains how to add, edit, and remove partner venues from the Deep Dive Brewing Co website.
+
+> **Warning:** Saving changes writes to the live production database immediately. Double-check addresses, links, and beer availability before saving.
+
+## Viewing partner venues
+
+1. Sign in to the admin dashboard at https://deepdivebrewing.com/admin.
+2. Select the **Venues** tab.
+3. The left panel shows venue records sorted by **Sort Order**.
+4. Click a venue name to load it into the form on the right.
+
+## Creating a venue
+
+1. In the **Venues** tab, click the **New** button above the venue list.
+2. The form on the right clears and shows empty default values.
+3. Fill in the required fields.
+4. Select which beers the venue carries, has on tap, or has in can.
+5. Click **Save Venue**.
+
+## Editing an existing venue
+
+1. Click the venue name in the left panel.
+2. Update the fields you want to change.
+3. Click **Save Venue**.
+
+## Available fields
+
+| Field | Required | What it does |
+|---|---|---|
+| **Name** | Yes | The venue's display name. |
+| **Slug** | Yes | The URL-friendly identifier. Used as the Firestore document ID. Should be lowercase and hyphenated, for example `tropics-cafe`. |
+| **Type** | Yes | Choose **Bar / Restaurant** or **Retail**. |
+| **Location Name** | Recommended | The island or region. This controls how venues are grouped on `/where-to-buy`. See the region section below for exact values. |
+| **Sort Order** | Yes | Controls the order venues appear within their group. Lower numbers appear first. |
+| **Carries Beers** | Optional | Check every beer the venue currently carries in any format. |
+| **On Tap** | Optional | Check beers the venue has on draft tap. |
+| **In Can** | Optional | Check beers the venue sells in cans. |
+| **Website** | Optional | The venue's website URL. Must include `https://`. |
+| **Maps Link** | Optional | A link to Google Maps or another mapping service for directions. |
+| **Instagram** | Optional | The venue's Instagram URL. |
+| **Facebook** | Optional | The venue's Facebook URL. |
+| **Public Notes** | Optional | Extra text shown on the public venue card, for example "Ask about the rotating tap." |
+| **Public** | Yes | If checked, the venue is visible on `/where-to-buy`. Uncheck to hide it. |
+
+## Region names and grouping logic
+
+The `/where-to-buy` page groups venues by the **Location Name** field. The public page uses these rules to decide the heading for each group:
+
+- If the location name contains `sxm`, `maarten`, or `martin`, the heading displays as **Sint Maarten / Saint Martin / SXM**.
+- If the location name contains `statia` or `eustatius`, the heading displays as **Sint Eustatius / Statia**.
+- Any other value has its first letter capitalized and is used as-is.
+
+### Recommended exact values
+
+Use simple, consistent values so grouping works predictably:
+
+- `Saba`
+- `SXM` (or `Sint Maarten`)
+- `Statia` (or `Sint Eustatius`)
+
+Examples:
+
+- A venue on Saba should have **Location Name** set to `Saba`.
+- A venue on Sint Maarten should use `SXM` or `Sint Maarten`.
+- A venue on Saint Martin (French side) should use `Saint Martin` or `SXM`.
+
+## How locations appear on `/where-to-buy`
+
+- Only venues with **Public** checked are shown.
+- Venues are grouped under headings based on **Location Name**.
+- Inside each group, venues are sorted by **Sort Order**.
+- Each venue card shows the name, type badge, public notes, and the beers listed under **On Tap** and **In Can**.
+- Links for Website, Directions, Instagram, and Facebook appear when those fields are filled.
+
+## Making Directions links work reliably
+
+The **Maps Link** field should be a full URL. The public page opens it in a new tab.
+
+Recommended format:
+
+```
+https://www.google.com/maps/dir/?api=1&destination=<latitude>,<longitude>
+```
+
+or
+
+```
+https://www.google.com/maps/search/?api=1&query=<venue+name+location>
+```
+
+For example:
+
+```
+https://www.google.com/maps/search/?api=1&query=Tropics+Cafe+Saba
+```
+
+Always test the link by opening it in a browser before saving.
+
+## Removing or temporarily hiding a location
+
+The admin form does **not** have a delete button. To remove a venue from public view:
+
+1. Open the venue record.
+2. Uncheck **Public**.
+3. Click **Save Venue**.
+
+The record stays in Firestore but is hidden from `/where-to-buy`. Only a developer can permanently delete the document.
+
+## Avoiding duplicate venue records
+
+To prevent duplicates:
+
+- Search the venue list before creating a new record.
+- Use a consistent slug format, for example `tropics-cafe-saba`.
+- If you accidentally create a duplicate, edit the unwanted record to uncheck **Public** and ask a developer to delete it from Firestore.
+
+> **Important:** Changing the slug of an existing venue saves a **new** Firestore document and leaves the old document in place. To avoid duplicates, only set the slug when creating the venue; do not rename it later unless you also hide or remove the old record.
+
+## Pre-publish checklist
+
+Before saving a new or updated venue, confirm:
+
+- [ ] Name and slug are correct and unique.
+- [ ] Slug is lowercase, hyphenated, and URL-safe.
+- [ ] Type is correct (Bar / Restaurant or Retail).
+- [ ] Location Name uses one of the recommended region values.
+- [ ] Sort order is set.
+- [ ] Website link is a full `https://` URL (if provided).
+- [ ] Maps Link is a working URL that opens directions (if provided).
+- [ ] Social links are full URLs (if provided).
+- [ ] Beer selections (Carries, On Tap, In Can) are accurate.
+- [ ] Public Notes are clear and useful (if provided).
+- [ ] **Public** is checked if the venue should be live.
+- [ ] A site rebuild is triggered if you want the change reflected in the static sitemap immediately.

--- a/docs/admin/trade-inquiries.md
+++ b/docs/admin/trade-inquiries.md
@@ -1,0 +1,104 @@
+# Trade Inquiries
+
+This guide explains how wholesale and trade inquiries reach the team, what information is collected, and how to handle submissions safely.
+
+## Where trade inquiries originate
+
+Visitors submit trade inquiries through the form on the public page:
+
+https://deepdivebrewing.com/trade
+
+The form is also linked from the beer listing and individual beer pages.
+
+## Fields collected
+
+The form asks for the following information:
+
+| Field | Required | Notes |
+|---|---|---|
+| **Business Name** | Yes | The bar, restaurant, hotel, retail store, or distributor. |
+| **Contact Name** | Yes | The person requesting the trade partnership. |
+| **Email** | Yes | Used as the reply-to address. |
+| **Phone / WhatsApp** | No | Optional contact number. |
+| **Venue Type** | Yes | One of: Bar, Restaurant, Hotel, Retail, Distributor, Other. |
+| **Message** | No | Any extra details the submitter wants to share. |
+
+There is also a hidden honeypot field named `website`. Humans never see it. If it is filled, the submission is treated as spam and silently discarded.
+
+## Backend handling
+
+When a visitor submits the form:
+
+1. The browser sends a `POST` request to `/api/trade-inquiry`.
+2. The server validates that the required fields are present.
+3. If the honeypot field is filled, the request is ignored but responds with success so bots do not know they were blocked.
+4. The server checks a per-IP rate limit (5 submissions per 10 minutes).
+5. The server sends an email through **Resend** to the address configured in `TRADE_INQUIRY_TO_EMAIL`.
+6. The email's reply-to address is set to the submitter's email.
+
+The email subject is:
+
+```
+Trade Inquiry — <Business Name> (<Contact Name>)
+```
+
+The email body contains all submitted fields in a simple HTML table.
+
+## Where inquiries are delivered
+
+Inquiries are delivered to the email address set in the `TRADE_INQUIRY_TO_EMAIL` environment variable. There is no admin dashboard inbox for trade inquiries.
+
+> **Note:** The codebase also contains a `tradeLeads` Firestore collection definition and a helper function (`lib/trade-leads.ts`), but the current trade-inquiry form does **not** write submissions to Firestore. If you need a Firestore copy for tracking, contact a developer. This is labeled as **Needs confirmation** for the intended workflow.
+
+## Expected success behavior
+
+After a successful submission:
+
+- The form is replaced with a thank-you message.
+- A `trade_form_success` analytics event is recorded (no personal information is included).
+
+## Expected failure behavior
+
+If submission fails:
+
+- The form shows an error message describing the problem.
+- A `trade_form_error` analytics event is recorded.
+- Common failure reasons include missing required fields, rate limiting, or an email service configuration problem.
+
+## How administrators should respond
+
+1. Monitor the inbox configured in `TRADE_INQUIRY_TO_EMAIL`.
+2. Reply directly to the submitter using the reply-to address.
+3. Keep business and contact details confidential; do not forward inquiry emails to unauthorized recipients.
+4. Track follow-up status in your preferred CRM or email workflow. The website does not currently provide a lead-management interface.
+
+## Privacy considerations
+
+- The form collects business contact information. Treat it as personal/business data.
+- Do not add submitted emails to marketing lists without consent.
+- Do not store inquiry details in insecure locations.
+- Only authorized staff with access to the `TRADE_INQUIRY_TO_EMAIL` inbox should handle inquiries.
+
+## What information must never be sent to analytics
+
+Analytics events are configured to avoid personally identifiable information (PII). The following must **never** be sent to analytics:
+
+- Email addresses.
+- Phone numbers.
+- Business names tied to an individual.
+- Any message text from the form.
+
+The current analytics events (`trade_form_start`, `trade_form_success`, `trade_form_error`) only record the event category, CTA location, and venue type.
+
+## Safe testing procedures
+
+> **Warning:** Submitting the live form on https://deepdivebrewing.com/trade creates a real inquiry email unless the email service is misconfigured. Do not use production to run tests.
+
+To test safely:
+
+1. Use a local development environment (`npm run dev`) with a test email address configured in `TRADE_INQUIRY_TO_EMAIL`.
+2. Use the Resend test domain or a controlled inbox.
+3. Do not enter real customer data during testing.
+4. Delete test emails after verification.
+
+If you must test on production, coordinate with the email recipient so the test submission is expected and can be deleted.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,158 @@
+# Deployment Guide
+
+This guide describes how the Deep Dive Brewing Co website is built, previewed, and deployed.
+
+## Branch and pull-request workflow
+
+The repository uses Git with Vercel Git integration.
+
+1. Create a feature or fix branch from the main development branch.
+2. Make your changes.
+3. Push the branch to GitHub.
+4. Open a pull request.
+5. Vercel automatically builds a preview deployment for the pull request.
+6. Review the preview, run checks, and merge when ready.
+
+> **Note:** The production branch name is configured in Vercel. Typically it is `main`, but confirm in the Vercel project settings if you are unsure.
+
+## Vercel preview deployments
+
+Every push to a branch and every pull request creates a preview URL. You can use this URL to verify changes with real Firebase data before merging.
+
+Preview URLs look like:
+
+```
+https://deepdivebrewing-<random>-<team>.vercel.app
+```
+
+### Important notes about previews
+
+- Preview deployments use the same Firebase project as production if the environment variables point to it.
+- Preview domains must be added to **Firebase Authentication > Settings > Authorized domains** if you need to test Google sign-in on a preview URL.
+- The `frame-src` Content-Security-Policy is built at deploy time using the value of `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`. If that environment variable is not set for the preview, the fallback domain is used.
+
+## Production deployment
+
+Merging an approved pull request into the production branch triggers a production deploy on Vercel.
+
+You can also deploy manually from the Vercel dashboard or CLI, but this guide assumes Git-based deployment.
+
+## Environment-variable scopes
+
+Environment variables are managed in the Vercel dashboard.
+
+### Public variables (available in the browser)
+
+These variables are prefixed with `NEXT_PUBLIC_` and are embedded in the client bundle. They are safe to expose because they configure Firebase client access only. Actual data access is controlled by Firebase Security Rules.
+
+Examples:
+
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
+- `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`
+- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+- `NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID`
+- `NEXT_PUBLIC_SITE_URL`
+- `NEXT_PUBLIC_GA_ID`
+
+### Server-only variables
+
+These variables are used only by API routes or build-time scripts and must not be exposed to the browser.
+
+Examples:
+
+- `RESEND_API_KEY`
+- `TRADE_INQUIRY_TO_EMAIL`
+- `VERCEL_DEPLOY_HOOK_URL`
+- `FIREBASE_ADMIN_PROJECT_ID`
+- `FIREBASE_ADMIN_CLIENT_EMAIL`
+- `FIREBASE_ADMIN_PRIVATE_KEY`
+- `ADMIN_REBUILD_COOLDOWN_MS`
+
+## How to verify a preview with populated Firebase data
+
+Local development can run with sample or empty data. To verify a preview with real data:
+
+1. Open the Vercel preview URL.
+2. Navigate to `/beers` and confirm the current beer list loads.
+3. Visit `/where-to-buy` and confirm partner venues appear.
+4. Visit a beer detail page (`/beers/<slug>`) and confirm images load.
+5. Visit `/contact` and confirm the map renders.
+6. Visit `/admin` and confirm the sign-in button loads (complete sign-in only on an authorized domain).
+
+If data is missing, check that the preview environment variables match the production Firebase project.
+
+## Domain and redirect behavior
+
+The site is configured to redirect:
+
+- HTTP to HTTPS with a permanent 308 redirect.
+- `www.deepdivebrewing.com` to `deepdivebrewing.com` with a permanent 308 redirect.
+
+These redirects are defined in `next.config.ts`.
+
+## Admin-triggered rebuilds
+
+The admin dashboard has a **Rebuild Site** button. When clicked:
+
+1. The dashboard sends a Firebase ID token to `POST /api/admin/rebuild`.
+2. The server verifies the user is in the admin allow-list.
+3. The server calls the Vercel Deploy Hook configured in `VERCEL_DEPLOY_HOOK_URL`.
+4. Vercel starts a new production build.
+5. A cooldown prevents repeated rebuilds. The default cooldown is 10 minutes (`ADMIN_REBUILD_COOLDOWN_MS=600000`).
+
+The rebuild is needed because the following pages are static and only update at build time:
+
+- `/` (homepage)
+- `/beers`
+- `/where-to-buy`
+- `/about`
+- `/contact`
+- `/trade`
+- `sitemap.xml`
+
+Beer detail pages (`/beers/<slug>`) are rendered on demand, so they reflect Firestore changes without a rebuild.
+
+## Rollback procedure
+
+If a production deploy causes problems:
+
+1. Identify the last known good commit from the Git history or Vercel deployment list.
+2. In the Vercel dashboard, find the previous production deployment and click **Promote to Production**.
+   - This is usually the fastest rollback.
+3. Alternatively, revert the problematic commit in Git and merge the revert to the production branch.
+4. After rollback, verify the live site.
+
+> **Warning:** Promoting a previous deployment is faster than reverting and redeploying, but make sure the previous deployment is actually working before promoting it.
+
+## Post-deployment smoke tests
+
+After any production deployment, run through these checks:
+
+1. Load https://deepdivebrewing.com and confirm the homepage renders.
+2. Load `/beers` and confirm the beer grid appears.
+3. Click into a beer detail page and confirm the image and metadata load.
+4. Load `/where-to-buy` and confirm venue groups appear.
+5. Load `/contact` and confirm the map loads.
+6. Load `/trade` and confirm the inquiry form renders.
+7. Open the browser console and confirm there are no CSP violations or 404 errors.
+8. Test a Google sign-in attempt on `/admin` (complete login only if you are authorized).
+
+For a full checklist, see [Post-deployment checklist](./post-deployment-checklist.md).
+
+## How to confirm which commit is in production
+
+1. Open the Vercel dashboard for the project.
+2. Go to the production deployment.
+3. The deployment details show the Git commit SHA and message.
+4. Compare that commit with the latest commit in the repository's production branch.
+
+You can also check the response headers of the live site for build information, but the Vercel dashboard is the most reliable source.
+
+## Related guides
+
+- [Post-deployment checklist](./post-deployment-checklist.md)
+- [Troubleshooting](./troubleshooting.md)
+- [Admin handbook](../admin/README.md)

--- a/docs/operations/post-deployment-checklist.md
+++ b/docs/operations/post-deployment-checklist.md
@@ -1,0 +1,119 @@
+# Post-Deployment Checklist
+
+Run this checklist after every production deployment or after any significant content change.
+
+## Homepage
+
+- [ ] `https://deepdivebrewing.com/` loads without errors.
+- [ ] The hero image or video renders correctly.
+- [ ] The main heading and call-to-action buttons are visible.
+- [ ] The "Book a Brewery Tour" WhatsApp link works and is tracked as `tour_inquiry_click`.
+- [ ] The featured beers section shows the expected beers.
+- [ ] The "Where to Find Us" section and link to `/where-to-buy` work.
+
+## Beer listing
+
+- [ ] `https://deepdivebrewing.com/beers` loads.
+- [ ] The filter buttons (All, Core, Seasonal, Limited) work.
+- [ ] Each beer card shows the correct name, style, ABV, status, and image.
+- [ ] Clicking a beer card opens the correct detail page.
+- [ ] New beers added since the last build are visible.
+
+## Representative beer pages
+
+- [ ] Visit at least one Core and one Seasonal/Limited beer detail page.
+- [ ] The hero image loads.
+- [ ] The title, style, ABV, status, description, and tasting notes are correct.
+- [ ] The "Where to Buy" link works.
+- [ ] Product structured data is present in the page source (search for `"@type":"Product"`).
+
+## Where-to-buy page
+
+- [ ] `https://deepdivebrewing.com/where-to-buy` loads.
+- [ ] Venues are grouped under the expected region headings.
+- [ ] Each venue card shows the name, type, public notes, and beer availability.
+- [ ] Directions links open correctly.
+- [ ] Website and social links open correctly.
+
+## Contact map
+
+- [ ] `https://deepdivebrewing.com/contact` loads.
+- [ ] The Google Maps embed renders and shows the brewery location.
+- [ ] WhatsApp, email, hours, and address information are correct.
+
+## Admin login
+
+- [ ] `https://deepdivebrewing.com/admin` shows the sign-in button.
+- [ ] Clicking **Sign in with Google** opens the Google popup without CSP errors.
+- [ ] An authorized account reaches the dashboard.
+- [ ] No `frame-src` or `connect-src` CSP violations appear in the console.
+
+## Trade page
+
+- [ ] `https://deepdivebrewing.com/trade` loads.
+- [ ] The inquiry form displays all required fields.
+- [ ] Submitting the form (with a test address in a safe environment) returns a success message.
+- [ ] The honeypot field is hidden.
+
+## Firebase images
+
+- [ ] Beer card images load on `/beers`.
+- [ ] Beer hero images load on beer detail pages.
+- [ ] No `img-src` CSP violations appear.
+- [ ] No 402, 403, or 502 errors from `firebasestorage.googleapis.com` or `/_next/image`.
+
+## Mobile layouts
+
+- [ ] Repeat the homepage, beer listing, beer detail, where-to-buy, and contact checks on a mobile viewport (or mobile device).
+- [ ] The navigation menu opens and closes correctly.
+- [ ] No horizontal overflow is visible.
+- [ ] Touch targets are large enough to tap easily.
+
+## Redirects
+
+- [ ] `http://deepdivebrewing.com` redirects to `https://deepdivebrewing.com` with a 308.
+- [ ] `http://www.deepdivebrewing.com` redirects to `https://deepdivebrewing.com` with a 308.
+- [ ] `https://www.deepdivebrewing.com` redirects to `https://deepdivebrewing.com` with a 308.
+
+## Metadata and structured data
+
+- [ ] The homepage `<title>` and meta description look correct.
+- [ ] Beer detail pages have unique titles and descriptions.
+- [ ] Each page has a canonical URL.
+- [ ] Brewery structured data is present on the homepage and contact page.
+- [ ] Product structured data is present on beer detail pages.
+
+## Analytics
+
+- [ ] Google Analytics 4 and Vercel Analytics scripts load on deployed URLs.
+- [ ] Events such as `where_to_buy_click`, `directions_click`, `tour_inquiry_click`, `trade_form_start`, and `trade_form_success` fire when expected.
+- [ ] No personal information is sent with analytics events.
+
+## Browser console
+
+- [ ] Open the browser console on the homepage, `/beers`, a beer detail page, `/where-to-buy`, `/contact`, and `/admin`.
+- [ ] Look for CSP violations, 4xx/5xx errors, or JavaScript exceptions.
+- [ ] Ignore expected local-only messages such as Vercel Analytics 404s when running `npm run start` locally.
+
+## Response headers
+
+- [ ] Check that the `Content-Security-Policy` header is present.
+- [ ] Confirm `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` are present.
+- [ ] Verify the `frame-src` directive includes the current Firebase Auth origin.
+
+## 404 behavior
+
+- [ ] Visit a non-existent page such as `https://deepdivebrewing.com/this-page-does-not-exist`.
+- [ ] Confirm the site returns a styled 404 page.
+- [ ] Confirm the HTTP status is 404.
+
+## Final steps
+
+- [ ] Note the production deployment URL and commit SHA.
+- [ ] Confirm the Vercel deployment status shows "Ready."
+- [ ] Communicate the deployment status to the team.
+- [ ] Keep a brief record of what was changed and any issues found.
+
+## Need help?
+
+If any check fails, see the [Troubleshooting Guide](./troubleshooting.md) or contact the site developer with the failing URL and any browser console errors.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,329 @@
+# Troubleshooting Guide
+
+Use this guide to diagnose and fix common problems with the Deep Dive Brewing Co website. If a step is marked with a cost or data risk, proceed carefully.
+
+---
+
+## Beer photos not loading
+
+**Visible symptom:** A beer detail page or the `/beers` grid shows a broken image icon or blank space where a beer image should be.
+
+**Likely causes:**
+
+- The image file is missing from Firebase Storage.
+- The image path in the beer record is wrong.
+- Firebase Storage is returning an error because of billing or permissions.
+- Next.js Image Optimization cannot fetch or process the image.
+- The browser is showing a stale cached image.
+
+**Safe diagnostic checks:**
+
+1. Open the beer detail page in a browser.
+2. Right-click the broken image and open the image URL in a new tab.
+3. Check the browser console for `img-src` CSP errors.
+4. In the admin dashboard, open the beer record and confirm the **Card Image Path** and **Hero Image Path** values.
+5. Check the Vercel build logs for image-optimization errors.
+
+**Recommended fix:**
+
+- Re-upload the image in the admin dashboard and save the beer record.
+- If the direct Firebase Storage URL returns a billing error, see [Firebase 402/403 errors](#firebase-402403-errors) below.
+- If the direct URL works but the optimized URL fails, see [Next.js image optimizer 502 errors](#nextjs-image-optimizer-502-errors) below.
+- Clear the browser cache or hard-refresh the page.
+
+**When to escalate:** If the problem affects many images at once or re-uploading does not help, contact a developer with the failing URL and the browser console output.
+
+---
+
+## Google admin login failing
+
+**Visible symptom:** You click **Sign in with Google** on `/admin` but nothing happens, the popup closes, or you see an error message.
+
+**Likely causes:**
+
+- Popups are blocked.
+- The browser is in a strict privacy mode or container.
+- The current domain is not authorized in Firebase Authentication.
+- The Firebase Auth helper iframe is blocked by CSP.
+- You are signing in with a Google account that is not in the admin allow-list.
+- Third-party cookies are blocked.
+
+**Safe diagnostic checks:**
+
+1. Open the browser console and look for CSP errors, `auth/` errors, or 403/429 errors.
+2. Try an incognito/private window with extensions disabled.
+3. Confirm the domain in the address bar is in Firebase Authentication authorized domains.
+4. Confirm the email you are using is in `lib/admin-emails.ts`, `firestore.rules`, and `storage.rules`.
+
+**Recommended fix:**
+
+- Allow popups and third-party cookies for `deepdivebrewing.com`.
+- Add the preview or production domain to Firebase Authentication authorized domains.
+- Confirm `frame-src` in `next.config.ts` includes the Firebase Auth helper origin derived from `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`.
+- Ask an owner to verify your email is on the allow-list in both code and rules.
+
+For detailed steps, see [Login and access troubleshooting](../admin/login-and-access.md).
+
+**When to escalate:** If you see a specific Firebase error code that you cannot resolve, share the exact code and browser console output with a developer.
+
+---
+
+## Contact map blank
+
+**Visible symptom:** The `/contact` page shows an empty box where the Google Maps embed should be.
+
+**Likely causes:**
+
+- The map iframe is blocked by `frame-src` CSP.
+- The Google Maps embed URL is malformed.
+- Network requests to Google Maps are blocked by a privacy extension.
+
+**Safe diagnostic checks:**
+
+1. Open the browser console and look for CSP violations mentioning `maps.google.com` or `www.google.com`.
+2. Inspect the iframe element and confirm the `src` URL is `https://www.google.com/maps?q=66+Fort+Bay+Road,+The+Bottom,+Saba&output=embed`.
+3. Try loading the embed URL directly in a browser tab.
+
+**Recommended fix:**
+
+- Confirm `frame-src` in `next.config.ts` includes `https://www.google.com` and `https://maps.google.com`.
+- If testing on a Vercel preview protected by SSO, the automated test may not reach the page; verify with a signed-in browser session.
+- Disable privacy extensions temporarily for the site.
+
+**When to escalate:** If the map works when loaded directly but not on the site, contact a developer to review the CSP and iframe URL.
+
+---
+
+## Public content missing
+
+**Visible symptom:** A beer, venue, or page section that should be live is not showing on the public site.
+
+**Likely causes:**
+
+- The record has **Public** unchecked in the admin dashboard.
+- The page is static and has not been rebuilt since the change.
+- Firestore has no matching public record.
+- The page is cached by the browser or a CDN.
+
+**Safe diagnostic checks:**
+
+1. Open the admin dashboard and confirm the record has **Public** checked.
+2. Visit the dynamic beer detail page (`/beers/<slug>`) directly; if it appears there but not on `/beers`, the listing page needs a rebuild.
+3. Check the Vercel deployment status to confirm the latest build finished.
+4. Hard-refresh the page.
+
+**Recommended fix:**
+
+- Check **Public** and save.
+- Trigger a site rebuild from the admin dashboard.
+- Clear browser cache and retry.
+
+**When to escalate:** If the data exists in Firestore and a rebuild does not help, contact a developer to check the build logs and Firestore indexes.
+
+---
+
+## Admin edits not appearing
+
+**Visible symptom:** You saved a change in the admin dashboard, but the public site still shows the old content.
+
+**Likely causes:**
+
+- The change was saved to Firestore but the static page has not been rebuilt.
+- You changed the slug, which created a new record while the old record is still public.
+- A cache is serving the old version.
+
+**Safe diagnostic checks:**
+
+1. Re-open the record in the admin dashboard to confirm the change was saved.
+2. Check whether the affected page is static or dynamic:
+   - Dynamic: `/beers/<slug>` updates on the next request.
+   - Static: `/beers`, `/where-to-buy`, `/`, `/contact`, `/about`, `/trade`, and `sitemap.xml` need a rebuild.
+3. Look for duplicate records if the slug was changed.
+
+**Recommended fix:**
+
+- Trigger a site rebuild from the admin dashboard.
+- If the slug was changed, uncheck **Public** on the old record and save.
+- Hard-refresh the public page.
+
+**When to escalate:** If edits never persist or affect the wrong record, contact a developer to inspect Firestore directly.
+
+---
+
+## Firebase 402/403 errors
+
+**Visible symptom:** Network requests to `firebasestorage.googleapis.com` or Firestore return `402 Payment Required` or `403 Forbidden`.
+
+**Likely causes:**
+
+- The Firebase project is on the Spark (free) plan, but Cloud Storage for Firebase requires the Blaze plan.
+- Billing is disabled or a payment method has expired.
+- Storage or Firestore security rules are too restrictive.
+
+**Safe diagnostic checks:**
+
+1. Open the Firebase console and check the billing status.
+2. Confirm the project is on the Blaze plan.
+3. Review the deployed `storage.rules` and `firestore.rules`.
+
+**Recommended fix:**
+
+- Re-enable billing or update the payment method in the Firebase console.
+- Wait a few minutes for services to resume.
+- If the error is a rule issue, redeploy the rules from the repository.
+
+> **Data/billing warning:** Do not repeatedly upload or delete files while billing is disabled; charges may apply once billing resumes, and data may already exist. Verify billing status first.
+
+**When to escalate:** If billing is active and 403 errors continue, contact a developer to review the security rules and IAM settings.
+
+---
+
+## Next.js image optimizer 502 errors
+
+**Visible symptom:** The browser console shows `502 OPTIMIZED_EXTERNAL_IMAGE_REQUEST_INVALID` for an image URL.
+
+**Likely causes:**
+
+- The upstream Firebase Storage request failed (billing, permissions, missing file).
+- The image URL points to a hostname not allowed in `images.remotePatterns`.
+- The image file is corrupted or in an unsupported format.
+
+**Safe diagnostic checks:**
+
+1. Open the original Firebase Storage URL directly to see if it returns a valid image.
+2. Check that the URL hostname is `firebasestorage.googleapis.com`.
+3. Check `next.config.ts` to confirm the hostname is in `images.remotePatterns`.
+
+**Recommended fix:**
+
+- Fix the upstream Firebase Storage issue first (billing, permissions, or missing file).
+- If the hostname is not allowed, add it to `images.remotePatterns` and redeploy.
+- Re-upload a valid image if the file is corrupted.
+
+**When to escalate:** If the direct Firebase Storage URL works but Next.js still returns 502, contact a developer with the failing optimized URL and the original URL.
+
+---
+
+## Firestore permission errors
+
+**Visible symptom:** The admin dashboard shows "Firestore permission denied" when saving a beer or venue, or public pages show no data.
+
+**Likely causes:**
+
+- The signed-in user is not in the admin allow-list in `firestore.rules`.
+- The security rules have not been deployed.
+- The browser is using an expired or invalid Firebase Auth token.
+
+**Safe diagnostic checks:**
+
+1. Confirm the signed-in email is in `firestore.rules` and `lib/admin-emails.ts`.
+2. Sign out and sign in again to refresh the token.
+3. Check the Firebase console to confirm the rules are deployed.
+
+**Recommended fix:**
+
+- Add the email to the allow-lists, redeploy the rules, and rebuild the site.
+- Sign out and sign back in.
+
+**When to escalate:** If permissions fail for all admins, contact a developer immediately; the security rules may have been overwritten or misconfigured.
+
+---
+
+## CSP violations
+
+**Visible symptom:** The browser console reports Content-Security-Policy violations for scripts, frames, images, or connections.
+
+**Likely causes:**
+
+- A new external service was added without updating the CSP.
+- The Firebase Auth helper origin changed.
+- Google Analytics, Maps, or YouTube origins are missing.
+
+**Safe diagnostic checks:**
+
+1. Read the exact violation message to identify the blocked origin and directive.
+2. Compare the origin with the directives in `next.config.ts`.
+
+**Recommended fix:**
+
+- Add only the specific origin needed to the relevant directive.
+- Do not use wildcards such as `https://*` or `'unsafe-eval'` unless absolutely necessary.
+- Rebuild and redeploy after changing `next.config.ts`.
+
+**When to escalate:** If the violation cannot be fixed without broadening the policy significantly, contact a developer to review the change.
+
+---
+
+## Vercel deployment failures
+
+**Visible symptom:** A Git push or manual deploy fails in Vercel, or the preview URL returns an error.
+
+**Likely causes:**
+
+- A TypeScript error.
+- An ESLint error.
+- A missing environment variable required at build time.
+- A Firebase request failed during static page generation.
+
+**Safe diagnostic checks:**
+
+1. Read the full Vercel build log.
+2. Run the same commands locally:
+   ```bash
+   npm run lint
+   npx tsc --noEmit
+   npm run build
+   ```
+3. Check that all required environment variables are set in the Vercel dashboard.
+
+**Recommended fix:**
+
+- Fix lint or type errors before pushing.
+- Add missing environment variables.
+- If Firestore permission warnings appear with dummy config, confirm the preview/production environment has the real Firebase values.
+
+**When to escalate:** If the build fails for a reason unrelated to code changes (for example, a Vercel platform error), contact Vercel support or a developer.
+
+---
+
+## Analytics scripts returning 404 locally
+
+**Visible symptom:** Running `npm run start` locally shows 404 errors for `/_vercel/insights/script.js` or `/_vercel/speed-insights/script.js`.
+
+**Likely cause:** Vercel Analytics and Speed Insights scripts are injected by the Vercel edge network. They are not served by the local Next.js server.
+
+**Recommended fix:** This is expected during local development and can be ignored. Verify these scripts load on a deployed Vercel preview or production URL.
+
+**When to escalate:** If the scripts also fail on a deployed Vercel URL, check that Analytics and Speed Insights are enabled in the Vercel project dashboard.
+
+---
+
+## Incorrect www or HTTP redirects
+
+**Visible symptom:** Visiting `http://deepdivebrewing.com`, `http://www.deepdivebrewing.com`, or `https://www.deepdivebrewing.com` does not redirect to `https://deepdivebrewing.com`.
+
+**Likely cause:** The redirect rules in `next.config.ts` are missing or misconfigured.
+
+**Safe diagnostic checks:**
+
+1. Test each URL variant with `curl -I` or a browser.
+2. Inspect the response headers for `location` and status code.
+
+**Recommended fix:**
+
+- Confirm `next.config.ts` contains the HTTP-to-HTTPS and www-to-non-www 308 redirects.
+- Redeploy the site after any change to `next.config.ts`.
+
+**When to escalate:** If redirects are configured but not applied, contact a developer; the issue may be at the DNS or Vercel project-domain level.
+
+---
+
+## General escalation checklist
+
+Before contacting a developer, gather:
+
+- The exact URL where the problem happens.
+- The browser and device (or if it is the Vercel build environment).
+- The exact error message or console output.
+- Steps you have already tried.
+- Whether the issue affects production, a preview, or local development.

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,12 @@ import createMDX from "@next/mdx";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://deepdivebrewing.com";
 
+const firebaseAuthDomain =
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "deepdivebrewing-web.firebaseapp.com";
+const firebaseAuthOrigin = firebaseAuthDomain.startsWith("http")
+  ? firebaseAuthDomain
+  : `https://${firebaseAuthDomain}`;
+
 const versionedCacheHeaders = [
   {
     key: "Cache-Control",
@@ -97,7 +103,7 @@ const nextConfig: NextConfig = {
               "font-src 'self'",
               "form-action 'self'",
               "frame-ancestors 'self'",
-              "frame-src 'self' https://www.google.com https://maps.google.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com",
+              `frame-src 'self' https://www.google.com https://maps.google.com https://accounts.google.com ${firebaseAuthOrigin} https://www.youtube.com https://www.youtube-nocookie.com`,
               "img-src 'self' data: blob: https://firebasestorage.googleapis.com https://*.googleusercontent.com https://*.google-analytics.com https://*.googletagmanager.com https://*.gstatic.com https://va.vercel-scripts.com",
               "media-src 'self' https://firebasestorage.googleapis.com",
               "object-src 'none'",

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(__filename), "..");
+const files = [];
+
+const ignoredDirs = new Set(["node_modules", ".git", ".next", ".vercel", "dist", "out"]);
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (ignoredDirs.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full);
+    else if (full.endsWith(".md")) files.push(full);
+  }
+}
+walk(root);
+
+const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+const failures = [];
+
+for (const file of files) {
+  const content = fs.readFileSync(file, "utf8");
+  let match;
+  while ((match = linkRegex.exec(content)) !== null) {
+    const url = match[2];
+    if (/^https?:\/\//.test(url) || url.startsWith("mailto:") || url.startsWith("#")) continue;
+    const target = path.resolve(path.dirname(file), url.split("#")[0]);
+    if (!fs.existsSync(target)) {
+      failures.push(`${path.relative(root, file)} -> ${url}`);
+    }
+  }
+}
+
+if (failures.length) {
+  console.log("Broken relative markdown links:");
+  for (const failure of failures) console.log(failure);
+  process.exit(1);
+}
+
+console.log("All relative markdown links resolve.");


### PR DESCRIPTION
Add a full set of administrator and operations guides covering auth, beer/location management, images and storage, trade inquiries, deployment, troubleshooting, and post-deployment checks. Update the root README with project overview, commands, env-variable names, and links to the new docs. Include a small link-checking helper script.

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Improve project maintainability by documenting administration and operations workflows and strengthening repository guidance.

Enhancements:
- Expand the README with project overview, architecture, setup, environment variables, commands, deployment, security, and documentation links.
- Add administrator guides for authentication, beer and venue management, image storage, and trade inquiry handling.
- Add operations guides covering deployment, troubleshooting, and post-deployment verification.
- Allow the Content Security Policy to include the configured Firebase Authentication origin.

Documentation:
- Document administrator workflows, access management, content updates, media handling, and trade inquiry operations.
- Document deployment workflows, rollback procedures, troubleshooting scenarios, and production smoke checks.

Chores:
- Add a helper script that validates relative Markdown links across the repository.