### PR TITLE
Fix bootstrap-superadmin script for Node execution

### DIFF
--- a/lib/admin-audit-common.ts
+++ b/lib/admin-audit-common.ts
@@ -2,6 +2,9 @@ export function dropUndefinedValues(value: unknown): unknown {
   if (value === undefined) return undefined;
   if (value === null || typeof value !== "object") return value;
   if (Array.isArray(value)) return value.map(dropUndefinedValues);
+  // Only recurse into plain objects so Firestore Timestamp, Date, and other
+  // class instances are preserved as typed values.
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
 
   const entries = Object.entries(value).filter(([, v]) => v !== undefined);
   return Object.fromEntries(

--- a/scripts/bootstrap-superadmin.ts
+++ b/scripts/bootstrap-superadmin.ts
@@ -96,41 +96,90 @@ async function main() {
     process.exit(0);
   }
 
+  // Set the custom claim first. If the Firestore write/audit fails afterwards,
+  // we roll the claim back to the previous value so the bootstrap is not left
+  // half-applied.
+  const previousClaims = userRecord.customClaims ?? null;
+
   if (needsClaim) {
-    await auth.setCustomUserClaims(userRecord.uid, {
-      admin: true,
-      role: "superadmin",
-    });
-    console.log("Custom claim set.");
+    try {
+      await auth.setCustomUserClaims(userRecord.uid, {
+        admin: true,
+        role: "superadmin",
+      });
+      console.log("Custom claim set.");
+    } catch (error) {
+      console.error(
+        "Failed to set custom claim:",
+        error instanceof Error ? error.message : error
+      );
+      process.exit(1);
+    }
   }
 
-  const now = Timestamp.now();
-  const recordUpdate = {
-    email,
-    role: "superadmin",
-    status: "active",
-    createdAt: recordData?.createdAt ?? now,
-    createdBy: recordData?.createdBy ?? userRecord.uid,
-    updatedAt: now,
-    updatedBy: userRecord.uid,
-    lastLoginAt: now,
-  };
-  await recordRef.set(dropUndefinedValues(recordUpdate) as Record<string, unknown>, { merge: true });
-  console.log("adminUsers record updated.");
+  // Commit the adminUsers record and the audit log in a single Firestore
+  // transaction so an audit-write failure cannot leave the record updated
+  // without an accompanying audit entry.
+  try {
+    await db.runTransaction(async (t) => {
+      const snap = await t.get(recordRef);
+      const currentData = snap.data();
+      const now = Timestamp.now();
 
-  const auditRecord = {
-    action: "bootstrap" as const,
-    targetUid: userRecord.uid,
-    targetEmail: email,
-    newRole: "superadmin" as const,
-    newStatus: "active" as const,
-    actingUid: userRecord.uid,
-    actingEmail: email,
-    metadata: { source: "bootstrap-script" },
-    timestamp: now,
-  };
-  await db.collection("adminAuditLogs").add(dropUndefinedValues(auditRecord) as Record<string, unknown>);
-  console.log("Audit log written.");
+      const recordUpdate = {
+        email,
+        role: "superadmin",
+        status: "active",
+        createdAt: currentData?.createdAt ?? now,
+        createdBy: currentData?.createdBy ?? userRecord.uid,
+        updatedAt: now,
+        updatedBy: userRecord.uid,
+        lastLoginAt: now,
+      };
+      t.set(
+        recordRef,
+        dropUndefinedValues(recordUpdate) as Record<string, unknown>,
+        { merge: true }
+      );
+
+      const auditRef = db.collection("adminAuditLogs").doc();
+      const auditRecord = {
+        action: "bootstrap" as const,
+        targetUid: userRecord.uid,
+        targetEmail: email,
+        newRole: "superadmin" as const,
+        newStatus: "active" as const,
+        actingUid: userRecord.uid,
+        actingEmail: email,
+        metadata: { source: "bootstrap-script", needsClaim },
+        timestamp: now,
+      };
+      t.set(auditRef, dropUndefinedValues(auditRecord) as Record<string, unknown>);
+    });
+    console.log("adminUsers record and audit log written atomically.");
+  } catch (error) {
+    console.error(
+      "Failed to write admin record and audit log:",
+      error instanceof Error ? error.message : error
+    );
+
+    if (needsClaim) {
+      try {
+        await auth.setCustomUserClaims(userRecord.uid, previousClaims);
+        console.log("Rolled back custom claim to previous value.");
+      } catch (rollbackError) {
+        console.error(
+          "Custom claim rollback also failed:",
+          rollbackError instanceof Error ? rollbackError.message : rollbackError
+        );
+        console.error(
+          "The superadmin claim may still be set without a matching adminUsers record or audit log."
+        );
+      }
+    }
+
+    process.exit(1);
+  }
 
   console.log(
     "Bootstrap complete. Ask the superadmin to sign out and sign back in to refresh their ID token."

--- a/scripts/bootstrap-superadmin.ts
+++ b/scripts/bootstrap-superadmin.ts
@@ -1,24 +1,51 @@
-import "server-only";
-import { getFirebaseAdminAuth, getFirebaseAdminDb } from "@/lib/firebase-admin";
-import { normalizeEmail } from "@/lib/admin-auth";
-import { Timestamp } from "firebase-admin/firestore";
+import { cert, getApps, initializeApp, type App } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { dropUndefinedValues } from "@/lib/admin-audit-common";
+import { getProtectedAdminEmail, normalizeEmail } from "@/lib/admin-common";
 
 const dryRun = process.argv.includes("--dry-run");
 
+function getPrivateKey() {
+  const key = process.env.FIREBASE_ADMIN_PRIVATE_KEY;
+  if (!key) return "";
+  return key.replace(/\\n/g, "\n");
+}
+
+function getFirebaseAdminApp(): App {
+  const existing = getApps()[0];
+  if (existing) return existing;
+
+  const projectId =
+    process.env.FIREBASE_ADMIN_PROJECT_ID ?? process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+  const privateKey = getPrivateKey();
+
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error(
+      "Missing Firebase Admin credentials. Set FIREBASE_ADMIN_PROJECT_ID, FIREBASE_ADMIN_CLIENT_EMAIL, and FIREBASE_ADMIN_PRIVATE_KEY."
+    );
+  }
+
+  return initializeApp({
+    credential: cert({ projectId, clientEmail, privateKey }),
+  });
+}
+
 async function main() {
-  const rawEmail = process.env.SUPER_ADMIN_EMAIL;
-  if (!rawEmail) {
+  const protectedEmail = getProtectedAdminEmail();
+  if (!protectedEmail) {
     console.error(
       "Error: SUPER_ADMIN_EMAIL is not set. Set it in your environment before running this script."
     );
     process.exit(1);
   }
 
-  const email = normalizeEmail(rawEmail);
+  const email = normalizeEmail(protectedEmail);
   console.log(`Bootstrap target email: ${email}`);
 
-  const auth = getFirebaseAdminAuth();
-  const db = getFirebaseAdminDb();
+  const auth = getAuth(getFirebaseAdminApp());
+  const db = getFirestore(getFirebaseAdminApp());
 
   let userRecord;
   try {
@@ -78,20 +105,32 @@ async function main() {
   }
 
   const now = Timestamp.now();
-  await recordRef.set(
-    {
-      email,
-      role: "superadmin",
-      status: "active",
-      createdAt: recordData?.createdAt ?? now,
-      createdBy: recordData?.createdBy ?? userRecord.uid,
-      updatedAt: now,
-      updatedBy: userRecord.uid,
-      lastLoginAt: now,
-    },
-    { merge: true }
-  );
+  const recordUpdate = {
+    email,
+    role: "superadmin",
+    status: "active",
+    createdAt: recordData?.createdAt ?? now,
+    createdBy: recordData?.createdBy ?? userRecord.uid,
+    updatedAt: now,
+    updatedBy: userRecord.uid,
+    lastLoginAt: now,
+  };
+  await recordRef.set(dropUndefinedValues(recordUpdate) as Record<string, unknown>, { merge: true });
   console.log("adminUsers record updated.");
+
+  const auditRecord = {
+    action: "bootstrap" as const,
+    targetUid: userRecord.uid,
+    targetEmail: email,
+    newRole: "superadmin" as const,
+    newStatus: "active" as const,
+    actingUid: userRecord.uid,
+    actingEmail: email,
+    metadata: { source: "bootstrap-script" },
+    timestamp: now,
+  };
+  await db.collection("adminAuditLogs").add(dropUndefinedValues(auditRecord) as Record<string, unknown>);
+  console.log("Audit log written.");
 
   console.log(
     "Bootstrap complete. Ask the superadmin to sign out and sign back in to refresh their ID token."

--- a/tests/lib/admin-audit.test.ts
+++ b/tests/lib/admin-audit.test.ts
@@ -30,4 +30,19 @@ describe("dropUndefinedValues", () => {
     assert.strictEqual(dropUndefinedValues(null), null);
     assert.strictEqual(dropUndefinedValues(undefined), undefined);
   });
+
+  it("preserves class instances instead of destructuring them", () => {
+    const date = new Date("2025-01-01T00:00:00.000Z");
+    class Box {
+      constructor(public value: unknown) {}
+    }
+    const box = new Box("keep");
+    const result = dropUndefinedValues({
+      date,
+      box,
+      removed: undefined,
+    }) as { date: Date; box: Box };
+    assert.strictEqual(result.date, date);
+    assert.strictEqual(result.box, box);
+  });
 });


### PR DESCRIPTION
The migration script imported server-only modules and the shared Firebase Admin helper, which cannot run outside Next.js.

Initialize Firebase Admin directly in the script from environment variables, import only non-server-only helpers, sanitize payloads with dropUndefinedValues, and write a bootstrap audit record.

Dry-run still previews planned claim and adminUsers record changes.

Verified: type-check, tests, lint, and dry-run all pass.

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Make the superadmin bootstrap script independently executable and ensure its claim, admin record, and audit changes remain consistent.

New Features:
- Add atomic bootstrap audit logging alongside superadmin record updates.

Bug Fixes:
- Make the bootstrap-superadmin script runnable directly under Node by removing Next.js-only dependencies and initializing Firebase Admin from environment credentials.
- Prevent partial bootstrap state by rolling back custom claims when the Firestore record or audit transaction fails.
- Preserve Firestore Timestamp, Date, and other class instances when sanitizing payloads.

Enhancements:
- Use sanitized payloads for bootstrap Firestore writes and resolve the protected administrator email consistently.

Tests:
- Add coverage confirming that undefined fields are removed without altering class instances.