### PR TITLE
Fix admin Access panel: timestamp serialization and Resend invitation…

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,9 @@ NEXT_PUBLIC_SITE_URL=https://deepdivebrewing.com
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 RESEND_API_KEY=re_xxxxxxxxx
 TRADE_INQUIRY_TO_EMAIL=your-email@example.com
+ADMIN_INVITE_FROM_EMAIL=invitations@your-domain.com
+# Optional cooldown in milliseconds before an invitation email can be resent (default 60,000).
+ADMIN_INVITE_RESEND_COOLDOWN_MS=60000
 VERCEL_DEPLOY_HOOK_URL=https://api.vercel.com/v1/integrations/deploy/xxxxxxxxxxxxxxxx
 FIREBASE_ADMIN_PROJECT_ID=
 FIREBASE_ADMIN_CLIENT_EMAIL=

--- a/app/api/admin/invitations/[id]/resend/route.ts
+++ b/app/api/admin/invitations/[id]/resend/route.ts
@@ -9,6 +9,7 @@ import {
   getAdminSiteUrl,
   sendAdminInvitationEmail,
 } from "@/lib/admin-invitation-email";
+import { runResendInvitationCore } from "@/lib/admin-invitation-resend-core";
 import {
   getInvitationById,
   recordInvitationEmailAttempt,
@@ -26,6 +27,19 @@ import type { AdminInvitation } from "@/lib/admin-types";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+function mergeLatestEmailFields(
+  invitation: AdminInvitation,
+  emailSent: boolean,
+  messageId?: string
+): AdminInvitation {
+  return {
+    ...invitation,
+    emailStatus: emailSent ? "sent" : "failed",
+    lastEmailAttemptAt: new Date() as unknown as AdminInvitation["lastEmailAttemptAt"],
+    messageId: emailSent ? messageId : undefined,
+  };
 }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
@@ -85,51 +99,49 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     }
 
     const { invitation } = claim;
-    const emailResult = await sendAdminInvitationEmail(invitation.email, invitation.role);
+    const adminUrl = `${getAdminSiteUrl()}/admin`;
 
-    await recordInvitationEmailAttempt(
-      invitation.id,
-      emailResult.ok ? "sent" : "failed",
-      emailResult.ok ? emailResult.messageId : undefined
-    );
-
-    await logAdminAudit({
-      action: "resend_invitation",
-      targetEmail: normalizeEmail(invitation.email),
-      newRole: invitation.role,
-      actingUid: decoded.uid,
-      actingEmail: normalizeEmail(decoded.email),
-      metadata: {
-        invitationId: invitation.id,
-        emailSent: emailResult.ok,
-        messageId: emailResult.ok ? emailResult.messageId : undefined,
-        error: emailResult.ok ? undefined : emailResult.error,
-      },
-    }).catch((auditError) => {
-      console.error("Failed to log resend_invitation audit:", auditError);
+    const coreResult = await runResendInvitationCore({
+      invitation,
+      sendEmail: sendAdminInvitationEmail,
+      recordDelivery: (id, status, messageId) =>
+        recordInvitationEmailAttempt(id, status, messageId),
+      audit: (metadata) =>
+        logAdminAudit({
+          action: "resend_invitation",
+          targetEmail: normalizeEmail(invitation.email),
+          newRole: invitation.role,
+          actingUid: decoded.uid,
+          actingEmail: normalizeEmail(decoded.email),
+          metadata,
+        }),
+      logError: console.error,
     });
 
-    const updatedInvitation = await getInvitationById(invitation.id);
+    let updatedInvitation: AdminInvitation | null = null;
+    try {
+      updatedInvitation = await getInvitationById(invitation.id);
+    } catch (viewError) {
+      console.error("Failed to load invitation after resend:", viewError);
+    }
+
     const view = updatedInvitation
       ? serializeAdminInvitation(updatedInvitation)
-      : serializeAdminInvitation(invitation);
-
-    if (emailResult.ok) {
-      return NextResponse.json({
-        ok: true,
-        emailResent: true,
-        invitation: view,
-        adminUrl: `${getAdminSiteUrl()}/admin`,
-      });
-    }
+      : serializeAdminInvitation(
+          mergeLatestEmailFields(
+            invitation,
+            coreResult.emailSent,
+            coreResult.messageId
+          )
+        );
 
     return NextResponse.json({
       ok: true,
-      emailResent: false,
-      warning:
-        "The email could not be resent. The invitation remains pending.",
+      emailResent: coreResult.emailSent,
+      deliveryRecorded: coreResult.deliveryRecorded,
+      ...(coreResult.warning ? { warning: coreResult.warning } : {}),
       invitation: view,
-      adminUrl: `${getAdminSiteUrl()}/admin`,
+      adminUrl,
     });
   } catch (error) {
     const message =

--- a/app/api/admin/invitations/[id]/resend/route.ts
+++ b/app/api/admin/invitations/[id]/resend/route.ts
@@ -1,0 +1,95 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  assertSuperAdmin,
+  normalizeEmail,
+  verifyAdminIdToken,
+} from "@/lib/admin-auth";
+import { logAdminAudit } from "@/lib/admin-audit";
+import { getAdminSiteUrl, sendAdminInvitationEmail } from "@/lib/admin-invitation-email";
+import {
+  getInvitationById,
+  recordInvitationEmailAttempt,
+} from "@/lib/admin-invitations";
+import { canResendInvitation } from "@/lib/admin-invitation-resend-policy";
+import { serializeAdminInvitation } from "@/lib/admin-serializers";
+import {
+  badRequestResponse,
+  getBearerToken,
+  unauthorizedResponse,
+} from "@/lib/api-auth";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const idToken = getBearerToken(req);
+  if (!idToken) return unauthorizedResponse();
+
+  try {
+    const { id: invitationId } = await params;
+    const decoded = await verifyAdminIdToken(idToken);
+    assertSuperAdmin(decoded);
+
+    const invitation = await getInvitationById(invitationId);
+    if (!invitation) {
+      return badRequestResponse("Invitation not found.");
+    }
+
+    const resendCheck = canResendInvitation(invitation, Date.now());
+    if (!resendCheck.ok) {
+      return NextResponse.json(
+        { ok: false, error: resendCheck.reason },
+        { status: 429 }
+      );
+    }
+
+    const emailResult = await sendAdminInvitationEmail(invitation.email, invitation.role);
+
+    await recordInvitationEmailAttempt(
+      invitation.id,
+      emailResult.ok ? "sent" : "failed",
+      emailResult.ok ? emailResult.messageId : undefined
+    );
+
+    if (emailResult.ok) {
+      await logAdminAudit({
+        action: "resend_invitation",
+        targetEmail: normalizeEmail(invitation.email),
+        newRole: invitation.role,
+        actingUid: decoded.uid,
+        actingEmail: normalizeEmail(decoded.email),
+        metadata: {
+          invitationId: invitation.id,
+          messageId: emailResult.messageId,
+        },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        emailResent: true,
+        invitation: serializeAdminInvitation(
+          (await getInvitationById(invitation.id)) ?? invitation
+        ),
+        adminUrl: `${getAdminSiteUrl()}/admin`,
+      });
+    }
+
+    console.error("Resend invitation failed:", emailResult.error);
+
+    return NextResponse.json({
+      ok: true,
+      emailResent: false,
+      warning:
+        "The email could not be resent. The invitation remains pending.",
+      invitation: serializeAdminInvitation(
+        (await getInvitationById(invitation.id)) ?? invitation
+      ),
+      adminUrl: `${getAdminSiteUrl()}/admin`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to resend invitation.";
+    const status = (error as { status?: number }).status ?? 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/app/api/admin/invitations/[id]/resend/route.ts
+++ b/app/api/admin/invitations/[id]/resend/route.ts
@@ -5,18 +5,24 @@ import {
   verifyAdminIdToken,
 } from "@/lib/admin-auth";
 import { logAdminAudit } from "@/lib/admin-audit";
-import { getAdminSiteUrl, sendAdminInvitationEmail } from "@/lib/admin-invitation-email";
+import {
+  getAdminSiteUrl,
+  sendAdminInvitationEmail,
+} from "@/lib/admin-invitation-email";
 import {
   getInvitationById,
   recordInvitationEmailAttempt,
 } from "@/lib/admin-invitations";
 import { canResendInvitation } from "@/lib/admin-invitation-resend-policy";
+import { getFirebaseAdminDb } from "@/lib/firebase-admin";
 import { serializeAdminInvitation } from "@/lib/admin-serializers";
 import {
   badRequestResponse,
   getBearerToken,
   unauthorizedResponse,
 } from "@/lib/api-auth";
+import { Timestamp } from "firebase-admin/firestore";
+import type { AdminInvitation } from "@/lib/admin-types";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -31,19 +37,54 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     const decoded = await verifyAdminIdToken(idToken);
     assertSuperAdmin(decoded);
 
-    const invitation = await getInvitationById(invitationId);
-    if (!invitation) {
-      return badRequestResponse("Invitation not found.");
-    }
+    const db = getFirebaseAdminDb();
+    const invitationRef = db.collection("adminInvitations").doc(invitationId);
 
-    const resendCheck = canResendInvitation(invitation, Date.now());
-    if (!resendCheck.ok) {
+    const claim = await db.runTransaction(async (t) => {
+      const snap = await t.get(invitationRef);
+      if (!snap.exists) {
+        return {
+          ok: false as const,
+          reason: "Invitation not found.",
+          currentStatus: "",
+        };
+      }
+
+      const current = {
+        id: snap.id,
+        ...(snap.data() as Omit<AdminInvitation, "id">),
+      };
+
+      const resendCheck = canResendInvitation(current, Date.now());
+      if (!resendCheck.ok) {
+        return {
+          ok: false as const,
+          reason: resendCheck.reason ?? "Resend not allowed.",
+          currentStatus: current.status,
+        };
+      }
+
+      // Claim the send attempt before calling Resend so concurrent resend
+      // requests cannot pass the cooldown check simultaneously.
+      t.update(invitationRef, {
+        lastEmailAttemptAt: Timestamp.now(),
+      });
+
+      return { ok: true as const, invitation: current };
+    });
+
+    if (!claim.ok) {
+      if (claim.reason === "Invitation not found.") {
+        return badRequestResponse(claim.reason);
+      }
+      const status = claim.currentStatus !== "pending" ? 409 : 429;
       return NextResponse.json(
-        { ok: false, error: resendCheck.reason },
-        { status: 429 }
+        { ok: false, error: claim.reason },
+        { status }
       );
     }
 
+    const { invitation } = claim;
     const emailResult = await sendAdminInvitationEmail(invitation.email, invitation.role);
 
     await recordInvitationEmailAttempt(
@@ -52,43 +93,47 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       emailResult.ok ? emailResult.messageId : undefined
     );
 
-    if (emailResult.ok) {
-      await logAdminAudit({
-        action: "resend_invitation",
-        targetEmail: normalizeEmail(invitation.email),
-        newRole: invitation.role,
-        actingUid: decoded.uid,
-        actingEmail: normalizeEmail(decoded.email),
-        metadata: {
-          invitationId: invitation.id,
-          messageId: emailResult.messageId,
-        },
-      });
+    await logAdminAudit({
+      action: "resend_invitation",
+      targetEmail: normalizeEmail(invitation.email),
+      newRole: invitation.role,
+      actingUid: decoded.uid,
+      actingEmail: normalizeEmail(decoded.email),
+      metadata: {
+        invitationId: invitation.id,
+        emailSent: emailResult.ok,
+        messageId: emailResult.ok ? emailResult.messageId : undefined,
+        error: emailResult.ok ? undefined : emailResult.error,
+      },
+    }).catch((auditError) => {
+      console.error("Failed to log resend_invitation audit:", auditError);
+    });
 
+    const updatedInvitation = await getInvitationById(invitation.id);
+    const view = updatedInvitation
+      ? serializeAdminInvitation(updatedInvitation)
+      : serializeAdminInvitation(invitation);
+
+    if (emailResult.ok) {
       return NextResponse.json({
         ok: true,
         emailResent: true,
-        invitation: serializeAdminInvitation(
-          (await getInvitationById(invitation.id)) ?? invitation
-        ),
+        invitation: view,
         adminUrl: `${getAdminSiteUrl()}/admin`,
       });
     }
-
-    console.error("Resend invitation failed:", emailResult.error);
 
     return NextResponse.json({
       ok: true,
       emailResent: false,
       warning:
         "The email could not be resent. The invitation remains pending.",
-      invitation: serializeAdminInvitation(
-        (await getInvitationById(invitation.id)) ?? invitation
-      ),
+      invitation: view,
       adminUrl: `${getAdminSiteUrl()}/admin`,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to resend invitation.";
+    const message =
+      error instanceof Error ? error.message : "Failed to resend invitation.";
     const status = (error as { status?: number }).status ?? 500;
     return NextResponse.json({ ok: false, error: message }, { status });
   }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -18,6 +18,7 @@ import {
   serializeAdminInvitation,
   serializeAdminUser,
 } from "@/lib/admin-serializers";
+import type { AdminInvitationView } from "@/lib/types";
 import {
   badRequestResponse,
   forbiddenResponse,
@@ -88,37 +89,70 @@ export async function POST(req: NextRequest) {
 
     const emailResult = await sendAdminInvitationEmail(invitation.email, invitation.role);
 
-    await recordInvitationEmailAttempt(
-      invitation.id,
-      emailResult.ok ? "sent" : "failed",
-      emailResult.ok ? emailResult.messageId : undefined
-    );
+    let deliveryRecorded = true;
+    try {
+      await recordInvitationEmailAttempt(
+        invitation.id,
+        emailResult.ok ? "sent" : "failed",
+        emailResult.ok ? emailResult.messageId : undefined
+      );
+    } catch (recordError) {
+      console.error("Failed to record invitation email delivery:", recordError);
+      deliveryRecorded = false;
+    }
 
-    const updatedInvitation = await getInvitationById(invitation.id);
-    const view = updatedInvitation
-      ? serializeAdminInvitation(updatedInvitation)
-      : serializeAdminInvitation(invitation);
+    let view: AdminInvitationView;
+    try {
+      const updatedInvitation = await getInvitationById(invitation.id);
+      view = updatedInvitation
+        ? serializeAdminInvitation(updatedInvitation)
+        : serializeAdminInvitation(invitation);
+    } catch (viewError) {
+      console.error("Failed to load invitation after email attempt:", viewError);
+      view = serializeAdminInvitation(invitation);
+    }
 
-    await logAdminAudit({
-      action: "create_invitation",
-      targetEmail: email,
-      newRole: role,
-      actingUid: decoded.uid,
-      actingEmail: normalizeEmail(decoded.email),
-      metadata: {
-        invitationId: invitation.id,
-        emailSent: emailResult.ok,
-        messageId: emailResult.ok ? emailResult.messageId : undefined,
-      },
-    });
+    try {
+      await logAdminAudit({
+        action: "create_invitation",
+        targetEmail: email,
+        newRole: role,
+        actingUid: decoded.uid,
+        actingEmail: normalizeEmail(decoded.email),
+        metadata: {
+          invitationId: invitation.id,
+          emailSent: emailResult.ok,
+          messageId: emailResult.ok ? emailResult.messageId : undefined,
+          deliveryRecorded,
+        },
+      });
+    } catch (auditError) {
+      console.error("Failed to log create_invitation audit:", auditError);
+    }
 
-    if (emailResult.ok) {
+    const adminUrl = `${getAdminSiteUrl()}/admin`;
+
+    if (emailResult.ok && deliveryRecorded) {
       return NextResponse.json({
         ok: true,
         invitationCreated: true,
         emailSent: true,
+        deliveryRecorded: true,
         invitation: view,
-        adminUrl: `${getAdminSiteUrl()}/admin`,
+        adminUrl,
+      });
+    }
+
+    if (emailResult.ok && !deliveryRecorded) {
+      return NextResponse.json({
+        ok: true,
+        invitationCreated: true,
+        emailSent: true,
+        deliveryRecorded: false,
+        warning:
+          "Invitation created and the email was sent, but the delivery record could not be saved. The invitation is still pending.",
+        invitation: view,
+        adminUrl,
       });
     }
 
@@ -126,10 +160,11 @@ export async function POST(req: NextRequest) {
       ok: true,
       invitationCreated: true,
       emailSent: false,
+      deliveryRecorded,
       warning:
         "Invitation created, but the email could not be delivered. The invitation remains pending.",
       invitation: view,
-      adminUrl: `${getAdminSiteUrl()}/admin`,
+      adminUrl,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to create invitation.";

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -6,11 +6,18 @@ import {
   verifyAdminIdToken,
 } from "@/lib/admin-auth";
 import { logAdminAudit } from "@/lib/admin-audit";
+import { getAdminSiteUrl, sendAdminInvitationEmail } from "@/lib/admin-invitation-email";
 import {
   createInvitation,
+  getInvitationById,
   listPendingInvitations,
+  recordInvitationEmailAttempt,
 } from "@/lib/admin-invitations";
 import { listAdminUsers } from "@/lib/admin-users";
+import {
+  serializeAdminInvitation,
+  serializeAdminUser,
+} from "@/lib/admin-serializers";
 import {
   badRequestResponse,
   forbiddenResponse,
@@ -37,7 +44,11 @@ export async function GET(req: NextRequest) {
       listPendingInvitations(),
     ]);
 
-    return NextResponse.json({ ok: true, users, invitations });
+    return NextResponse.json({
+      ok: true,
+      users: users.map(serializeAdminUser),
+      invitations: invitations.map(serializeAdminInvitation),
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to load administrators.";
     const status = (error as { status?: number }).status ?? 500;
@@ -75,16 +86,51 @@ export async function POST(req: NextRequest) {
 
     const invitation = await createInvitation(email, role, decoded.uid);
 
+    const emailResult = await sendAdminInvitationEmail(invitation.email, invitation.role);
+
+    await recordInvitationEmailAttempt(
+      invitation.id,
+      emailResult.ok ? "sent" : "failed",
+      emailResult.ok ? emailResult.messageId : undefined
+    );
+
+    const updatedInvitation = await getInvitationById(invitation.id);
+    const view = updatedInvitation
+      ? serializeAdminInvitation(updatedInvitation)
+      : serializeAdminInvitation(invitation);
+
     await logAdminAudit({
       action: "create_invitation",
       targetEmail: email,
       newRole: role,
       actingUid: decoded.uid,
       actingEmail: normalizeEmail(decoded.email),
-      metadata: { invitationId: invitation.id },
+      metadata: {
+        invitationId: invitation.id,
+        emailSent: emailResult.ok,
+        messageId: emailResult.ok ? emailResult.messageId : undefined,
+      },
     });
 
-    return NextResponse.json({ ok: true, invitation });
+    if (emailResult.ok) {
+      return NextResponse.json({
+        ok: true,
+        invitationCreated: true,
+        emailSent: true,
+        invitation: view,
+        adminUrl: `${getAdminSiteUrl()}/admin`,
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      invitationCreated: true,
+      emailSent: false,
+      warning:
+        "Invitation created, but the email could not be delivered. The invitation remains pending.",
+      invitation: view,
+      adminUrl: `${getAdminSiteUrl()}/admin`,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to create invitation.";
     const status = (error as { status?: number }).status ?? 500;

--- a/components/admin-access.tsx
+++ b/components/admin-access.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { formatAdminDate, formatAdminDateTime } from "@/lib/admin-format";
 import type { AdminRole, AdminUserView, AdminInvitationView } from "@/lib/types";
 import type { User } from "firebase/auth";
 
@@ -72,17 +73,65 @@ export function AdminAccessPanel({ user, onStatusMessage }: AdminAccessPanelProp
         },
         body: JSON.stringify({ email, role: inviteRole }),
       });
-      const data = (await res.json()) as { ok?: boolean; error?: string };
+      const data = (await res.json()) as {
+        ok?: boolean;
+        emailSent?: boolean;
+        warning?: string;
+        error?: string;
+      };
       if (!res.ok || !data.ok) {
         onStatusMessage(data.error ?? "Invitation failed.");
         return;
       }
       setInviteEmail("");
-      onStatusMessage(`Invitation sent to ${email} as ${inviteRole}.`);
+      if (data.emailSent) {
+        onStatusMessage(`Invitation created and email sent to ${email} as ${inviteRole}.`);
+      } else {
+        onStatusMessage(data.warning ?? "Invitation created, but the email could not be sent.");
+      }
       await load();
     } catch (error) {
       console.error(error);
       onStatusMessage("Invitation failed. Please try again.");
+    } finally {
+      setActionInProgress(null);
+    }
+  }
+
+  async function resend(invitation: AdminInvitationView) {
+    if (invitation.status !== "pending") return;
+    const actionKey = `resend-${invitation.id}`;
+    if (actionInProgress === actionKey) return;
+
+    setActionInProgress(actionKey);
+    try {
+      const idToken = await user.getIdToken();
+      const res = await fetch(`/api/admin/invitations/${invitation.id}/resend`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${idToken}` },
+      });
+      const data = (await res.json()) as {
+        ok?: boolean;
+        emailResent?: boolean;
+        warning?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.ok) {
+        onStatusMessage(data.error ?? "Resend failed.");
+        return;
+      }
+      if (data.emailResent) {
+        onStatusMessage("Invitation email resent.");
+      } else {
+        onStatusMessage(
+          data.warning ??
+            "The email could not be resent. The invitation remains pending."
+        );
+      }
+      await load();
+    } catch (error) {
+      console.error(error);
+      onStatusMessage("Resend failed. Please try again.");
     } finally {
       setActionInProgress(null);
     }
@@ -289,15 +338,34 @@ export function AdminAccessPanel({ user, onStatusMessage }: AdminAccessPanelProp
             {invitations.map((invitation) => (
               <li
                 key={invitation.id}
-                className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+                className="flex flex-col gap-3 py-3 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div>
                   <p className="font-medium">{invitation.email}</p>
                   <p className="text-sm text-muted-foreground">
-                    Role: {invitation.role} • Invited: {new Date(invitation.createdAt).toLocaleDateString()}
+                    Role: {invitation.role} • Invited: {formatAdminDate(invitation.createdAt)}
+                    {invitation.lastEmailAttemptAt ? (
+                      <>
+                        {" "}
+                        • Last email: {formatAdminDateTime(invitation.lastEmailAttemptAt)}
+                        {invitation.emailStatus ? ` (${invitation.emailStatus})` : ""}
+                      </>
+                    ) : null}
                   </p>
                 </div>
-                <Badge variant="outline">Pending</Badge>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Pending</Badge>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={actionInProgress === `resend-${invitation.id}`}
+                    onClick={() => resend(invitation)}
+                  >
+                    {actionInProgress === `resend-${invitation.id}`
+                      ? "Sending..."
+                      : "Resend email"}
+                  </Button>
+                </div>
               </li>
             ))}
           </ul>

--- a/components/admin-access.tsx
+++ b/components/admin-access.tsx
@@ -84,10 +84,12 @@ export function AdminAccessPanel({ user, onStatusMessage }: AdminAccessPanelProp
         return;
       }
       setInviteEmail("");
-      if (data.emailSent) {
+      if (data.warning) {
+        onStatusMessage(data.warning);
+      } else if (data.emailSent) {
         onStatusMessage(`Invitation created and email sent to ${email} as ${inviteRole}.`);
       } else {
-        onStatusMessage(data.warning ?? "Invitation created, but the email could not be sent.");
+        onStatusMessage("Invitation created, but the email could not be sent.");
       }
       await load();
     } catch (error) {
@@ -120,12 +122,13 @@ export function AdminAccessPanel({ user, onStatusMessage }: AdminAccessPanelProp
         onStatusMessage(data.error ?? "Resend failed.");
         return;
       }
-      if (data.emailResent) {
+      if (data.warning) {
+        onStatusMessage(data.warning);
+      } else if (data.emailResent) {
         onStatusMessage("Invitation email resent.");
       } else {
         onStatusMessage(
-          data.warning ??
-            "The email could not be resent. The invitation remains pending."
+          "The email could not be resent. The invitation remains pending."
         );
       }
       await load();

--- a/lib/admin-format.ts
+++ b/lib/admin-format.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-safe formatters for administrative values.
+ *
+ * These helpers are intentionally lenient so that malformed or missing server
+ * data never produces UI errors such as "Invalid Date".
+ */
+
+export function formatAdminDate(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "Unknown";
+
+  const asString = typeof value === "number" ? String(value) : String(value);
+  if (!asString || asString === "undefined") return "Unknown";
+
+  const date = new Date(asString);
+  return Number.isNaN(date.getTime()) ? "Unknown" : date.toLocaleDateString();
+}
+
+export function formatAdminDateTime(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "Unknown";
+
+  const asString = typeof value === "number" ? String(value) : String(value);
+  if (!asString || asString === "undefined") return "Unknown";
+
+  const date = new Date(asString);
+  return Number.isNaN(date.getTime()) ? "Unknown" : date.toLocaleString();
+}

--- a/lib/admin-invitation-email-common.ts
+++ b/lib/admin-invitation-email-common.ts
@@ -1,0 +1,61 @@
+export interface AdminInvitationEmail {
+  to: string;
+  from: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+export function buildAdminInvitationEmail(options: {
+  to: string;
+  from: string;
+  role: string;
+  adminUrl: string;
+}): AdminInvitationEmail {
+  const { to, from, role, adminUrl } = options;
+  const safeTo = escapeHtml(to);
+  const safeRole = escapeHtml(role);
+  const safeAdminUrl = adminUrl;
+
+  const subject = "You have been invited to Deep Dive Brewing Co";
+
+  const html = `
+    <div style="font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; color: #1a1a1a;">
+      <h1 style="font-size: 24px; margin-bottom: 16px;">Deep Dive Brewing Co</h1>
+      <p>You have been invited to join the Deep Dive Brewing Co admin dashboard as a <strong>${safeRole}</strong>.</p>
+      <p style="margin: 24px 0;">
+        <a href="${safeAdminUrl}" style="display: inline-block; padding: 12px 24px; background-color: #1a1a1a; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600;">Go to admin dashboard</a>
+      </p>
+      <p>Sign in with the exact Google account you were invited with: <strong>${safeTo}</strong></p>
+      <p style="color: #737373; font-size: 14px;">Your access will not be granted until you accept this invitation by signing in at the admin dashboard. Do not share this link.</p>
+    </div>
+  `.trim();
+
+  const text = `Deep Dive Brewing Co
+
+You have been invited to join the Deep Dive Brewing Co admin dashboard as a ${role}.
+
+Go to the admin dashboard: ${adminUrl}
+
+Sign in with the exact Google account you were invited with: ${to}
+
+Your access will not be granted until you accept this invitation by signing in at the admin dashboard. Do not share this link.
+`.trim();
+
+  return {
+    to,
+    from,
+    subject,
+    html,
+    text,
+  };
+}

--- a/lib/admin-invitation-email.ts
+++ b/lib/admin-invitation-email.ts
@@ -1,20 +1,17 @@
 import "server-only";
 import { Resend } from "resend";
 import { buildAdminInvitationEmail } from "@/lib/admin-invitation-email-common";
-
-export interface SentInvitationEmail {
-  ok: true;
-  messageId: string;
-}
-
-export interface FailedInvitationEmail {
-  ok: false;
-  error: string;
-}
+import type {
+  ResendEmailResult,
+  FailedEmailResult,
+  SendEmailFunction,
+} from "@/lib/admin-invitation-resend-core";
 
 export type SendAdminInvitationEmailResult =
-  | SentInvitationEmail
-  | FailedInvitationEmail;
+  | ResendEmailResult
+  | FailedEmailResult;
+
+export type { ResendEmailResult, FailedEmailResult, SendEmailFunction };
 
 export function getAdminInviteFromEmail(): string | undefined {
   return (
@@ -29,10 +26,10 @@ export function getAdminSiteUrl(): string {
   return raw.replace(/\/+$/, "");
 }
 
-export async function sendAdminInvitationEmail(
-  email: string,
-  role: string
-): Promise<SendAdminInvitationEmailResult> {
+export const sendAdminInvitationEmail: SendEmailFunction = async (
+  email,
+  role
+) => {
   const apiKey = process.env.RESEND_API_KEY;
   const from = getAdminInviteFromEmail();
 

--- a/lib/admin-invitation-email.ts
+++ b/lib/admin-invitation-email.ts
@@ -1,0 +1,87 @@
+import "server-only";
+import { Resend } from "resend";
+import { buildAdminInvitationEmail } from "@/lib/admin-invitation-email-common";
+
+export interface SentInvitationEmail {
+  ok: true;
+  messageId: string;
+}
+
+export interface FailedInvitationEmail {
+  ok: false;
+  error: string;
+}
+
+export type SendAdminInvitationEmailResult =
+  | SentInvitationEmail
+  | FailedInvitationEmail;
+
+export function getAdminInviteFromEmail(): string | undefined {
+  return (
+    process.env.ADMIN_INVITE_FROM_EMAIL ??
+    process.env.RESEND_FROM_EMAIL ??
+    undefined
+  );
+}
+
+export function getAdminSiteUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL ?? "https://deepdivebrewing.com";
+  return raw.replace(/\/+$/, "");
+}
+
+export async function sendAdminInvitationEmail(
+  email: string,
+  role: string
+): Promise<SendAdminInvitationEmailResult> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = getAdminInviteFromEmail();
+
+  if (!apiKey) {
+    console.error("Resend API key is not configured.");
+    return { ok: false, error: "Email service is not configured." };
+  }
+
+  if (!from) {
+    console.error("Admin invitation sender email is not configured.");
+    return { ok: false, error: "Invitation sender email is not configured." };
+  }
+
+  const resend = new Resend(apiKey);
+  const adminUrl = `${getAdminSiteUrl()}/admin`;
+
+  const { to, from: fromAddress, subject, html, text } = buildAdminInvitationEmail(
+    {
+      to: email,
+      from,
+      role,
+      adminUrl,
+    }
+  );
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: fromAddress,
+      to,
+      subject,
+      html,
+      text,
+    });
+
+    if (error) {
+      console.error("Resend invitation email error:", error);
+      return { ok: false, error: "Resend rejected the email request." };
+    }
+
+    if (!data?.id) {
+      return { ok: false, error: "Resend did not return a message identifier." };
+    }
+
+    return { ok: true, messageId: data.id };
+  } catch (sendError) {
+    console.error("Resend invitation send exception:", sendError);
+    return {
+      ok: false,
+      error: "An unexpected error occurred while sending the invitation email.",
+    };
+  }
+}

--- a/lib/admin-invitation-resend-core.ts
+++ b/lib/admin-invitation-resend-core.ts
@@ -1,0 +1,111 @@
+import type { AdminInvitation, AdminRole } from "@/lib/admin-types";
+
+export interface ResendEmailResult {
+  ok: true;
+  messageId: string;
+}
+
+export interface FailedEmailResult {
+  ok: false;
+  error: string;
+}
+
+export type SendEmailFunction = (
+  email: string,
+  role: AdminRole
+) => Promise<ResendEmailResult | FailedEmailResult>;
+
+export interface ResendInvitationCoreInput {
+  invitation: AdminInvitation;
+  sendEmail: SendEmailFunction;
+  recordDelivery: (
+    id: string,
+    status: "sent" | "failed",
+    messageId?: string
+  ) => Promise<void>;
+  audit: (metadata: Record<string, unknown>) => Promise<void>;
+  logError: (message: string, error?: unknown) => void;
+}
+
+export interface ResendInvitationCoreResult {
+  ok: true;
+  emailSent: boolean;
+  deliveryRecorded: boolean;
+  messageId?: string;
+  warning?: string;
+}
+
+export async function runResendInvitationCore(
+  input: ResendInvitationCoreInput
+): Promise<ResendInvitationCoreResult> {
+  const { invitation, sendEmail, recordDelivery, audit, logError } = input;
+
+  const emailResult = await sendEmail(invitation.email, invitation.role);
+
+  let deliveryRecorded = true;
+  try {
+    await recordDelivery(
+      invitation.id,
+      emailResult.ok ? "sent" : "failed",
+      emailResult.ok ? emailResult.messageId : undefined
+    );
+  } catch (recordError) {
+    deliveryRecorded = false;
+    logError("Failed to record invitation email delivery", recordError);
+  }
+
+  const auditMetadata: Record<string, unknown> = {
+    invitationId: invitation.id,
+    targetEmail: invitation.email,
+    role: invitation.role,
+    emailSent: emailResult.ok,
+    messageId: emailResult.ok ? emailResult.messageId : undefined,
+    deliveryRecorded,
+  };
+  if (!emailResult.ok) {
+    auditMetadata.error = emailResult.error;
+  }
+
+  try {
+    await audit(auditMetadata);
+  } catch (auditError) {
+    logError("Failed to write resend_invitation audit", auditError);
+  }
+
+  if (emailResult.ok) {
+    if (deliveryRecorded) {
+      return {
+        ok: true,
+        emailSent: true,
+        deliveryRecorded: true,
+        messageId: emailResult.messageId,
+      };
+    }
+    return {
+      ok: true,
+      emailSent: true,
+      deliveryRecorded: false,
+      messageId: emailResult.messageId,
+      warning:
+        "The email was sent, but the delivery status could not be saved. The invitation remains pending.",
+    };
+  }
+
+  if (deliveryRecorded) {
+    return {
+      ok: true,
+      emailSent: false,
+      deliveryRecorded: true,
+      warning:
+        "The email could not be sent. The failed status was recorded and the invitation remains pending.",
+    };
+  }
+
+  return {
+    ok: true,
+    emailSent: false,
+    deliveryRecorded: false,
+    warning:
+      "The email could not be sent and the failed status could not be recorded. The invitation remains pending.",
+  };
+}

--- a/lib/admin-invitation-resend-policy.ts
+++ b/lib/admin-invitation-resend-policy.ts
@@ -1,0 +1,46 @@
+import type { AdminInvitation } from "@/lib/admin-types";
+
+export interface ResendInvitationCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+function getDefaultCooldownMs(): number {
+  const configured = process.env.ADMIN_INVITE_RESEND_COOLDOWN_MS;
+  if (configured) {
+    const parsed = Number(configured);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return 60_000; // 1 minute
+}
+
+export function canResendInvitation(
+  invitation: AdminInvitation,
+  now: number
+): ResendInvitationCheck {
+  if (invitation.status !== "pending") {
+    return { ok: false, reason: "Only pending invitations can be resent." };
+  }
+
+  const lastAttempt = invitation.lastEmailAttemptAt;
+  if (lastAttempt) {
+    const lastAttemptMillis =
+      typeof (lastAttempt as { toMillis?: () => number }).toMillis === "function"
+        ? (lastAttempt as { toMillis: () => number }).toMillis()
+        : new Date(String(lastAttempt)).getTime();
+
+    if (!Number.isNaN(lastAttemptMillis)) {
+      const elapsed = now - lastAttemptMillis;
+      const cooldownMs = getDefaultCooldownMs();
+      if (elapsed < cooldownMs) {
+        const remainingSeconds = Math.ceil((cooldownMs - elapsed) / 1000);
+        return {
+          ok: false,
+          reason: `Please wait ${remainingSeconds} second(s) before resending this invitation.`,
+        };
+      }
+    }
+  }
+
+  return { ok: true };
+}

--- a/lib/admin-invitations.ts
+++ b/lib/admin-invitations.ts
@@ -52,6 +52,29 @@ export async function listPendingInvitations(): Promise<AdminInvitation[]> {
   }));
 }
 
+export async function getInvitationById(
+  id: string
+): Promise<AdminInvitation | null> {
+  const doc = await getAdminInvitationsCollection().doc(id).get();
+  if (!doc.exists) return null;
+  return { id: doc.id, ...(doc.data() as Omit<AdminInvitation, "id">) };
+}
+
+export async function recordInvitationEmailAttempt(
+  id: string,
+  status: "sent" | "failed",
+  messageId?: string
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    emailStatus: status,
+    lastEmailAttemptAt: Timestamp.now(),
+  };
+  if (messageId) {
+    payload.messageId = messageId;
+  }
+  await getAdminInvitationsCollection().doc(id).update(payload);
+}
+
 export async function markInvitationAccepted(
   invitationId: string,
   acceptedByUid: string

--- a/lib/admin-invitations.ts
+++ b/lib/admin-invitations.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { getFirebaseAdminDb } from "@/lib/firebase-admin";
 import { normalizeEmail } from "@/lib/admin-common";
 import type { AdminInvitation, AdminRole } from "@/lib/admin-types";
-import { Timestamp } from "firebase-admin/firestore";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
 const COLLECTION = "adminInvitations";
 
@@ -69,7 +69,9 @@ export async function recordInvitationEmailAttempt(
     emailStatus: status,
     lastEmailAttemptAt: Timestamp.now(),
   };
-  if (messageId) {
+  if (status === "failed") {
+    payload.messageId = FieldValue.delete();
+  } else if (messageId) {
     payload.messageId = messageId;
   }
   await getAdminInvitationsCollection().doc(id).update(payload);

--- a/lib/admin-serializers.ts
+++ b/lib/admin-serializers.ts
@@ -1,0 +1,63 @@
+import type { AdminUserRecord, AdminInvitation } from "@/lib/admin-types";
+import type { AdminUserView, AdminInvitationView } from "@/lib/types";
+
+interface TimestampLike {
+  toDate(): Date;
+}
+
+function isTimestampLike(value: unknown): value is TimestampLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "toDate" in value &&
+    typeof (value as { toDate: unknown }).toDate === "function"
+  );
+}
+
+function toIsoString(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value instanceof Date) return value.toISOString();
+  if (isTimestampLike(value)) return value.toDate().toISOString();
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+  }
+  if (typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  return undefined;
+}
+
+export function serializeAdminUser(record: AdminUserRecord): AdminUserView {
+  return {
+    uid: record.uid,
+    email: record.email,
+    displayName: record.displayName,
+    role: record.role,
+    status: record.status,
+    createdAt: toIsoString(record.createdAt) ?? "",
+    createdBy: record.createdBy,
+    updatedAt: toIsoString(record.updatedAt),
+    updatedBy: record.updatedBy,
+    lastLoginAt: toIsoString(record.lastLoginAt),
+  };
+}
+
+export function serializeAdminInvitation(
+  record: AdminInvitation
+): AdminInvitationView {
+  return {
+    id: record.id,
+    email: record.email,
+    role: record.role,
+    status: record.status,
+    invitedBy: record.invitedBy,
+    createdAt: toIsoString(record.createdAt) ?? "",
+    acceptedAt: toIsoString(record.acceptedAt),
+    acceptedBy: record.acceptedBy,
+    emailStatus: record.emailStatus,
+    lastEmailAttemptAt: toIsoString(record.lastEmailAttemptAt),
+    messageId: record.messageId,
+  };
+}

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -25,6 +25,9 @@ export interface AdminInvitation {
   createdAt: Timestamp;
   acceptedAt?: Timestamp;
   acceptedBy?: string;
+  emailStatus?: "pending" | "sent" | "failed";
+  lastEmailAttemptAt?: Timestamp;
+  messageId?: string;
 }
 
 export interface AdminAuditRecord {
@@ -32,6 +35,7 @@ export interface AdminAuditRecord {
     | "bootstrap"
     | "accept_invitation"
     | "create_invitation"
+    | "resend_invitation"
     | "cancel_invitation"
     | "update_admin"
     | "revoke_admin"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,4 +72,9 @@ export interface AdminInvitationView {
   status: "pending" | "accepted" | "cancelled";
   invitedBy: string;
   createdAt: string;
+  acceptedAt?: string;
+  acceptedBy?: string;
+  emailStatus?: "pending" | "sent" | "failed";
+  lastEmailAttemptAt?: string;
+  messageId?: string;
 }

--- a/tests/lib/admin-format.test.ts
+++ b/tests/lib/admin-format.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { formatAdminDate, formatAdminDateTime } from "@/lib/admin-format";
+
+describe("formatAdminDate", () => {
+  it("formats an ISO date string", () => {
+    const value = "2025-01-15T00:00:00.000Z";
+    const result = formatAdminDate(value);
+    assert.notStrictEqual(result, "Unknown");
+    assert.match(result, /2025/);
+  });
+
+  it("returns Unknown for undefined", () => {
+    assert.strictEqual(formatAdminDate(undefined), "Unknown");
+  });
+
+  it("returns Unknown for null", () => {
+    assert.strictEqual(formatAdminDate(null), "Unknown");
+  });
+
+  it("returns Unknown for an empty string", () => {
+    assert.strictEqual(formatAdminDate(""), "Unknown");
+  });
+
+  it("returns Unknown for an invalid date string", () => {
+    assert.strictEqual(formatAdminDate("not a date"), "Unknown");
+  });
+
+  it("returns Unknown for a raw Firestore Timestamp object that is not serializable", () => {
+    assert.strictEqual(formatAdminDate({ _seconds: 1735689600 }), "Unknown");
+  });
+});
+
+describe("formatAdminDateTime", () => {
+  it("formats an ISO date string including time", () => {
+    const value = "2025-01-15T12:30:00.000Z";
+    const result = formatAdminDateTime(value);
+    assert.notStrictEqual(result, "Unknown");
+  });
+
+  it("returns Unknown for an invalid value", () => {
+    assert.strictEqual(formatAdminDateTime("invalid"), "Unknown");
+  });
+});

--- a/tests/lib/admin-invitation-email-common.test.ts
+++ b/tests/lib/admin-invitation-email-common.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { buildAdminInvitationEmail } from "@/lib/admin-invitation-email-common";
+
+describe("buildAdminInvitationEmail", () => {
+  const email = buildAdminInvitationEmail({
+    to: "admin@example.com",
+    from: "invitations@deepdivebrewing.com",
+    role: "superadmin",
+    adminUrl: "https://deepdivebrewing.com/admin",
+  });
+
+  it("uses the normalized invited address as the recipient", () => {
+    assert.strictEqual(email.to, "admin@example.com");
+  });
+
+  it("uses the server-controlled sender address", () => {
+    assert.strictEqual(email.from, "invitations@deepdivebrewing.com");
+  });
+
+  it("uses the server-controlled admin URL in the HTML", () => {
+    assert.match(email.html, /https:\/\/deepdivebrewing\.com\/admin/);
+  });
+
+  it("includes the assigned role", () => {
+    assert.match(email.html, /superadmin/);
+    assert.match(email.text, /superadmin/);
+  });
+
+  it("includes Deep Dive Brewing Co branding", () => {
+    assert.match(email.html, /Deep Dive Brewing Co/);
+    assert.match(email.subject, /Deep Dive Brewing Co/);
+  });
+
+  it("mentions the exact invited Google account", () => {
+    assert.match(email.html, /admin@example\.com/);
+    assert.match(email.text, /admin@example\.com/);
+  });
+
+  it("states that access is not granted until the invitation is accepted", () => {
+    assert.match(
+      email.html,
+      /access will not be granted until you accept/i
+    );
+    assert.match(
+      email.text,
+      /access will not be granted until you accept/i
+    );
+  });
+
+  it("does not include a Firebase token, credential, or secret", () => {
+    const combined = `${email.html}\n${email.text}\n${email.subject}`;
+    assert.doesNotMatch(combined, /RESEND_API_KEY/);
+    assert.doesNotMatch(combined, /FIREBASE_ADMIN_PRIVATE_KEY/);
+    assert.doesNotMatch(combined, /BEGIN PRIVATE KEY/);
+    assert.doesNotMatch(combined, /Bearer\s+[a-zA-Z0-9_-]+/);
+    assert.doesNotMatch(combined, /idToken/);
+    assert.doesNotMatch(combined, /customClaims/);
+    assert.doesNotMatch(combined, /firebase.*app/);
+  });
+
+  it("includes a call-to-action button in the HTML", () => {
+    assert.match(email.html, /<a[^>]+href=/);
+  });
+});

--- a/tests/lib/admin-invitation-resend-core.test.ts
+++ b/tests/lib/admin-invitation-resend-core.test.ts
@@ -4,6 +4,7 @@ import {
   runResendInvitationCore,
   type ResendEmailResult,
   type FailedEmailResult,
+  type SendEmailFunction,
 } from "@/lib/admin-invitation-resend-core";
 import type { AdminInvitation, AdminRole } from "@/lib/admin-types";
 
@@ -23,7 +24,7 @@ function makeInvitation(
 
 function makeSendEmail(
   result: ResendEmailResult | FailedEmailResult
-): typeof import("@/lib/admin-invitation-resend-core").SendEmailFunction {
+): SendEmailFunction {
   return async () => result;
 }
 

--- a/tests/lib/admin-invitation-resend-core.test.ts
+++ b/tests/lib/admin-invitation-resend-core.test.ts
@@ -1,0 +1,162 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  runResendInvitationCore,
+  type ResendEmailResult,
+  type FailedEmailResult,
+} from "@/lib/admin-invitation-resend-core";
+import type { AdminInvitation, AdminRole } from "@/lib/admin-types";
+
+function makeInvitation(
+  overrides: Partial<AdminInvitation> = {}
+): AdminInvitation {
+  return {
+    id: "inv-1",
+    email: "admin@example.com",
+    role: "admin" as AdminRole,
+    status: "pending",
+    invitedBy: "uid-creator",
+    createdAt: new Date("2025-01-01") as unknown as AdminInvitation["createdAt"],
+    ...overrides,
+  };
+}
+
+function makeSendEmail(
+  result: ResendEmailResult | FailedEmailResult
+): typeof import("@/lib/admin-invitation-resend-core").SendEmailFunction {
+  return async () => result;
+}
+
+describe("runResendInvitationCore", () => {
+  it("returns success when Resend succeeds and metadata recording succeeds", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: makeSendEmail({ ok: true, messageId: "msg-1" }),
+      recordDelivery: async (id, status, messageId) => {
+        calls.push({ id, status, messageId });
+      },
+      audit: async (metadata) => {
+        calls.push({ type: "audit", metadata });
+      },
+      logError: () => undefined,
+    });
+
+    assert.deepStrictEqual(result, {
+      ok: true,
+      emailSent: true,
+      deliveryRecorded: true,
+      messageId: "msg-1",
+    });
+    assert.strictEqual(calls[0].status, "sent");
+    assert.strictEqual(calls[0].messageId, "msg-1");
+    assert.strictEqual(calls[1].type, "audit");
+  });
+
+  it("returns partial success when Resend succeeds but metadata recording fails", async () => {
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: makeSendEmail({ ok: true, messageId: "msg-2" }),
+      recordDelivery: async () => {
+        throw new Error("Firestore unavailable");
+      },
+      audit: async () => undefined,
+      logError: () => undefined,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.emailSent, true);
+    assert.strictEqual(result.deliveryRecorded, false);
+    assert.strictEqual(result.messageId, "msg-2");
+    assert.match(result.warning ?? "", /email was sent, but the delivery status/i);
+  });
+
+  it("records failed status when Resend fails", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: makeSendEmail({
+        ok: false,
+        error: "Resend rejected the email request.",
+      }),
+      recordDelivery: async (id, status, messageId) => {
+        calls.push({ id, status, messageId });
+      },
+      audit: async (metadata) => {
+        calls.push({ type: "audit", metadata });
+      },
+      logError: () => undefined,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.emailSent, false);
+    assert.strictEqual(result.deliveryRecorded, true);
+    assert.match(result.warning ?? "", /email could not be sent/i);
+    assert.strictEqual(calls[0].status, "failed");
+    assert.strictEqual(calls[0].messageId, undefined);
+    assert.strictEqual(calls[1].type, "audit");
+  });
+
+  it("returns structured failure when Resend fails and metadata recording also fails", async () => {
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: makeSendEmail({
+        ok: false,
+        error: "Resend rejected the email request.",
+      }),
+      recordDelivery: async () => {
+        throw new Error("Firestore unavailable");
+      },
+      audit: async () => undefined,
+      logError: () => undefined,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.emailSent, false);
+    assert.strictEqual(result.deliveryRecorded, false);
+    assert.match(
+      result.warning ?? "",
+      /email could not be sent and the failed status could not be recorded/i
+    );
+  });
+
+  it("logs audit failures without changing the API response", async () => {
+    const errors: string[] = [];
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: makeSendEmail({ ok: true, messageId: "msg-3" }),
+      recordDelivery: async () => undefined,
+      audit: async () => {
+        throw new Error("Audit write failed");
+      },
+      logError: (message) => {
+        errors.push(message);
+      },
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.emailSent, true);
+    assert.strictEqual(result.deliveryRecorded, true);
+    assert.ok(errors.some((m) => m.includes("resend_invitation audit")));
+  });
+
+  it("never exposes raw provider errors, credentials, or stack traces in the response", async () => {
+    const result = await runResendInvitationCore({
+      invitation: makeInvitation(),
+      sendEmail: async () => ({
+        ok: false as const,
+        error: "api-key-12345 was rejected by smtp.resend.com at line 42",
+      }),
+      recordDelivery: async () => undefined,
+      audit: async () => undefined,
+      logError: () => undefined,
+    });
+
+    const response = JSON.stringify(result);
+    assert.doesNotMatch(response, /api-key-12345/);
+    assert.doesNotMatch(response, /resend\.com/);
+    assert.doesNotMatch(response, /line 42/);
+    assert.doesNotMatch(response, /Firestore/);
+    assert.match(result.warning ?? "", /email could not be sent/i);
+  });
+});

--- a/tests/lib/admin-invitation-resend-policy.test.ts
+++ b/tests/lib/admin-invitation-resend-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { canResendInvitation } from "@/lib/admin-invitation-resend-policy";
+import type { AdminInvitation } from "@/lib/admin-types";
+
+function stubTimestamp(millis: number) {
+  return { toMillis: () => millis } as unknown as AdminInvitation["lastEmailAttemptAt"];
+}
+
+describe("canResendInvitation", () => {
+  const baseInvitation: AdminInvitation = {
+    id: "inv-1",
+    email: "pending@example.com",
+    role: "admin",
+    status: "pending",
+    invitedBy: "uid-creator",
+    createdAt: stubTimestamp(0) as unknown as AdminInvitation["createdAt"],
+  };
+
+  it("allows resending a pending invitation that has never been emailed", () => {
+    const result = canResendInvitation(baseInvitation, Date.now());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects resending an accepted invitation", () => {
+    const invitation: AdminInvitation = { ...baseInvitation, status: "accepted" };
+    const result = canResendInvitation(invitation, Date.now());
+    assert.strictEqual(result.ok, false);
+    assert.match(result.reason ?? "", /Only pending/i);
+  });
+
+  it("rejects resending a cancelled invitation", () => {
+    const invitation: AdminInvitation = { ...baseInvitation, status: "cancelled" };
+    const result = canResendInvitation(invitation, Date.now());
+    assert.strictEqual(result.ok, false);
+    assert.match(result.reason ?? "", /Only pending/i);
+  });
+
+  it("rejects resending within the default cooldown", () => {
+    const now = 1_000_000;
+    const invitation: AdminInvitation = {
+      ...baseInvitation,
+      lastEmailAttemptAt: stubTimestamp(now - 5_000) as unknown as AdminInvitation["lastEmailAttemptAt"],
+    };
+    const result = canResendInvitation(invitation, now);
+    assert.strictEqual(result.ok, false);
+    assert.match(result.reason ?? "", /wait/i);
+  });
+
+  it("allows resending after the default cooldown", () => {
+    const now = 1_000_000;
+    const invitation: AdminInvitation = {
+      ...baseInvitation,
+      lastEmailAttemptAt: stubTimestamp(now - 120_000) as unknown as AdminInvitation["lastEmailAttemptAt"],
+    };
+    const result = canResendInvitation(invitation, now);
+    assert.strictEqual(result.ok, true);
+  });
+});

--- a/tests/lib/admin-serializers.test.ts
+++ b/tests/lib/admin-serializers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  serializeAdminUser,
+  serializeAdminInvitation,
+} from "@/lib/admin-serializers";
+import type { AdminUserRecord, AdminInvitation } from "@/lib/admin-types";
+
+const timestamp = (date: Date) =>
+  ({
+    toDate: () => date,
+    toMillis: () => date.getTime(),
+  } as unknown as { toDate: () => Date });
+
+describe("serializeAdminUser", () => {
+  it("converts Firestore Timestamps to ISO strings", () => {
+    const createdAt = new Date("2025-01-01T00:00:00.000Z");
+    const updatedAt = new Date("2025-02-01T00:00:00.000Z");
+    const lastLoginAt = new Date("2025-03-01T00:00:00.000Z");
+
+    const record: AdminUserRecord = {
+      uid: "uid-1",
+      email: "a@example.com",
+      role: "admin",
+      status: "active",
+      createdAt: timestamp(createdAt) as unknown as AdminUserRecord["createdAt"],
+      createdBy: "uid-creator",
+      updatedAt: timestamp(updatedAt) as unknown as AdminUserRecord["updatedAt"],
+      updatedBy: "uid-editor",
+      lastLoginAt:
+        timestamp(lastLoginAt) as unknown as AdminUserRecord["lastLoginAt"],
+    };
+
+    const view = serializeAdminUser(record);
+    assert.strictEqual(view.createdAt, createdAt.toISOString());
+    assert.strictEqual(view.updatedAt, updatedAt.toISOString());
+    assert.strictEqual(view.lastLoginAt, lastLoginAt.toISOString());
+  });
+
+  it("leaves optional timestamp fields undefined when absent", () => {
+    const record: AdminUserRecord = {
+      uid: "uid-2",
+      email: "b@example.com",
+      role: "superadmin",
+      status: "active",
+      createdAt: timestamp(new Date()) as unknown as AdminUserRecord["createdAt"],
+    };
+
+    const view = serializeAdminUser(record);
+    assert.strictEqual(view.updatedAt, undefined);
+    assert.strictEqual(view.lastLoginAt, undefined);
+  });
+});
+
+describe("serializeAdminInvitation", () => {
+  it("converts createdAt and acceptedAt to ISO strings and includes email metadata", () => {
+    const createdAt = new Date("2025-04-01T00:00:00.000Z");
+    const acceptedAt = new Date("2025-04-02T00:00:00.000Z");
+    const lastEmailAttemptAt = new Date("2025-04-03T00:00:00.000Z");
+
+    const record: AdminInvitation = {
+      id: "inv-1",
+      email: "c@example.com",
+      role: "admin",
+      status: "accepted",
+      invitedBy: "uid-creator",
+      createdAt:
+        timestamp(createdAt) as unknown as AdminInvitation["createdAt"],
+      acceptedAt:
+        timestamp(acceptedAt) as unknown as AdminInvitation["acceptedAt"],
+      acceptedBy: "uid-acceptor",
+      emailStatus: "sent",
+      lastEmailAttemptAt:
+        timestamp(lastEmailAttemptAt) as unknown as AdminInvitation["lastEmailAttemptAt"],
+      messageId: "msg-1",
+    };
+
+    const view = serializeAdminInvitation(record);
+    assert.strictEqual(view.createdAt, createdAt.toISOString());
+    assert.strictEqual(view.acceptedAt, acceptedAt.toISOString());
+    assert.strictEqual(view.emailStatus, "sent");
+    assert.strictEqual(view.lastEmailAttemptAt, lastEmailAttemptAt.toISOString());
+    assert.strictEqual(view.messageId, "msg-1");
+  });
+});


### PR DESCRIPTION
… emails

Root causes:

- /api/admin/users returned raw Firebase Admin Timestamp objects to the client, causing Invalid Date in the Access panel.

- POST /api/admin/users created a pending invitation but never called Resend, so the UI incorrectly reported Invitation sent.

Changes:

- Add lib/admin-serializers.ts to convert all admin user and invitation Timestamps to ISO-8601 strings on the server, including createdAt, updatedAt, lastLoginAt, acceptedAt, lastEmailAttemptAt.

- Add lib/admin-format.ts with client-safe formatAdminDate and formatAdminDateTime that display Unknown for missing or malformed values.

- Add lib/admin-invitation-email-common.ts to build the invitation email (HTML/text) using server-controlled admin URL, role, and sender.

- Add lib/admin-invitation-email.ts (server-only) to send via Resend using ADMIN_INVITE_FROM_EMAIL with RESEND_FROM_EMAIL fallback and NEXT_PUBLIC_SITE_URL.

- Update POST /api/admin/users to send the email, record delivery metadata, and return a structured result with emailSent and warning when delivery fails.

- Add app/api/admin/invitations/[id]/resend/route.ts for superadmin-only resend with cooldown and audit.

- Add lib/admin-invitation-resend-policy.ts for cooldown and pending-status checks.

- Update components/admin-access.tsx to show Unknown dates, display last email attempt, and add a Resend email button with accurate status messages.

- Update lib/admin-types.ts and lib/types.ts for email delivery metadata and resend_invitation audit action.

- Add ADMIN_INVITE_FROM_EMAIL and ADMIN_INVITE_RESEND_COOLDOWN_MS to .env.local.example.

Verification: tsc, lint, 73 tests, build, md-links all pass. No real email sent during tests.

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Make admin invitations reliable by serializing timestamp data, sending and tracking invitation emails, and supporting safe, auditable resends.

New Features:
- Add server-side admin invitation email delivery through Resend with configurable sender and site URL.
- Add superadmin-only invitation resend functionality with cooldown enforcement and audit logging.
- Expose invitation email delivery status and resend controls in the admin Access panel.

Bug Fixes:
- Serialize Firebase Admin timestamps before returning admin data to prevent invalid dates in the Access panel.
- Report invitation creation and email delivery outcomes accurately instead of assuming invitations were sent.

Enhancements:
- Add resilient client-side date formatting with Unknown fallbacks for missing or malformed values.
- Track invitation email attempts, provider message IDs, and delivery failures in invitation data and API responses.

Documentation:
- Document the new invitation sender and resend cooldown settings in the local environment example.

Tests:
- Add coverage for timestamp serialization, safe date formatting, invitation email content, resend policy, and delivery result handling.